### PR TITLE
Sprint 2: Tile-based Homepage Dashboard

### DIFF
--- a/ScrumPilot.Web/Components/DashboardTile.razor
+++ b/ScrumPilot.Web/Components/DashboardTile.razor
@@ -1,0 +1,35 @@
+@using MudBlazor
+@inject NavigationManager Nav
+
+<MudPaper Class="dashboard-tile pa-4" Elevation="3" @onclick="Navigate">
+
+    <MudText Typo="Typo.h6">
+        @Title
+    </MudText>
+
+    @if (!string.IsNullOrWhiteSpace(Description))
+    {
+        <MudText Typo="Typo.body2" Class="mt-2">
+            @Description
+        </MudText>
+    }
+
+</MudPaper>
+
+@code {
+
+    [Parameter]
+    public string Title { get; set; } = "";
+
+    [Parameter]
+    public string Description { get; set; } = "";
+
+    [Parameter]
+    public string Href { get; set; } = "";
+
+    void Navigate()
+    {
+        Nav.NavigateTo(Href);
+    }
+
+}

--- a/ScrumPilot.Web/Pages/Home.razor
+++ b/ScrumPilot.Web/Pages/Home.razor
@@ -1,7 +1,29 @@
 ﻿@page "/"
 
-<PageTitle>Home</PageTitle>
+<MudContainer MaxWidth="MaxWidth.Large" Class="mt-6">
 
-<h1>ScrumPilot Project Dashboard</h1>
+<MudText Typo="Typo.h4">Scrum Pilot Dashboard</MudText>
 
-Generate and manage user stories efficiently.
+<MudGrid Spacing="3">
+
+<MudItem xs="12" sm="6" md="4">
+<DashboardTile Title="Scrum Board"
+Description="View sprint tasks"
+Href="/scrum-board"/>
+</MudItem>
+
+<MudItem xs="12" sm="6" md="4">
+<DashboardTile Title="Story Generation"
+Description="Generate user stories"
+Href="/storygeneration"/>
+</MudItem>
+
+<MudItem xs="12" sm="6" md="4">
+<DashboardTile Title="Draft Stories"
+Description="Review generated drafts"
+Href="/draft-stories"/>
+</MudItem>
+
+</MudGrid>
+
+</MudContainer>

--- a/ScrumPilot.Web/Pages/Home.razor.css
+++ b/ScrumPilot.Web/Pages/Home.razor.css
@@ -1,0 +1,11 @@
+.dashboard-tile {
+    cursor: pointer;
+    padding: 20px;
+    border-radius: 8px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-tile:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 6px 18px rgba(0,0,0,0.15);
+}

--- a/ScrumPilot.Web/wwwroot/css/app.css
+++ b/ScrumPilot.Web/wwwroot/css/app.css
@@ -106,3 +106,17 @@ code {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
     text-align: start;
 }
+
+/* Dashboard tiles */
+
+.dashboard-tile {
+    cursor: pointer;
+    padding: 20px;
+    border-radius: 8px;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.dashboard-tile:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 6px 18px rgba(0,0,0,0.15);
+}

--- a/ScrumPilot.Web/wwwroot/css/app.css
+++ b/ScrumPilot.Web/wwwroot/css/app.css
@@ -107,16 +107,3 @@ code {
     text-align: start;
 }
 
-/* Dashboard tiles */
-
-.dashboard-tile {
-    cursor: pointer;
-    padding: 20px;
-    border-radius: 8px;
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.dashboard-tile:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 6px 18px rgba(0,0,0,0.15);
-}


### PR DESCRIPTION
Implements a tile-based homepage dashboard for quick navigation.

Features:
- Responsive MudBlazor tile grid
- Tiles include title, description, and navigation action
- Routes to Scrum Board, Generate Stories, and Draft Stories
- Works independently of the Navbar
- Tiles can be easily added via the Home page configuration

Acceptance criteria verified during local testing.