### PR TITLE
Changed the scrum board page to use the database endpoints

### DIFF
--- a/ScrumPilot.Web/Pages/ScrumBoard.razor
+++ b/ScrumPilot.Web/Pages/ScrumBoard.razor
@@ -16,6 +16,13 @@
     }
     else
     {
+        @if (!string.IsNullOrWhiteSpace(_moveStoryErrorMessage))
+        {
+            <MudAlert Severity="Severity.Error" Dense="true" Class="mb-4" Icon="@Icons.Material.Filled.ErrorOutline">
+                @_moveStoryErrorMessage
+            </MudAlert>
+        }
+
         <MudContainer MaxWidth="MaxWidth.False" Class="pa-0">
             <MudDropContainer T="Story"
                               Items="@Items"
@@ -199,34 +206,86 @@
     private List<Story> Items = new();
     private bool _loading = true;
     private Story? SelectedStory;
+    private string _moveStoryErrorMessage = string.Empty;
 
     //Api Intergration for getting stories
     protected override async Task OnInitializedAsync()
-{
-    _loading = true;
-    Items = new();
-
-    try
     {
-        var stories = await Http.GetFromJsonAsync<List<Story>>("api/story/getAllStories");
-        if (stories is not null && stories.Any())
-            Items = stories;
+        await LoadStoriesAsync();
     }
-    catch
+
+    private async Task LoadStoriesAsync()
     {
+        _loading = true;
+        _moveStoryErrorMessage = string.Empty;
+        Items = new();
+
+        try
+        {
+            var stories = await Http.GetFromJsonAsync<List<Story>>("api/story/getAllStories");
+            if (stories is not null)
+            {
+                Items = stories;
+            }
+        }
+        catch
+        {
+            _moveStoryErrorMessage = "Unable to load stories from the server.";
+        }
+        finally
+        {
+            _loading = false;
+        }
     }
-    finally
-    {
-        _loading = false;
-    }
-}
 
 
-    private void OnItemDropped(MudItemDropInfo<Story> dropInfo)
+    private async Task OnItemDropped(MudItemDropInfo<Story> dropInfo)
     {
         // Dropzone identifiers are: "ToDo", "InProgress", "Done"
-        if (Enum.TryParse<StoryStatus>(dropInfo.DropzoneIdentifier, out var newStatus))
-            dropInfo.Item.Status = newStatus;
+        if (!Enum.TryParse<StoryStatus>(dropInfo.DropzoneIdentifier, out var newStatus))
+        {
+            _moveStoryErrorMessage = "Unable to move story: invalid destination column.";
+            return;
+        }
+
+        var originalStatus = dropInfo.Item.Status;
+        if (originalStatus == newStatus)
+        {
+            _moveStoryErrorMessage = string.Empty;
+            return;
+        }
+
+        _moveStoryErrorMessage = string.Empty;
+
+        // Optimistically move the card, then persist status to the backend.
+        dropInfo.Item.Status = newStatus;
+
+        try
+        {
+            dropInfo.Item.LastUpdated = DateTime.UtcNow;
+
+            var response = await Http.PutAsJsonAsync("api/story", dropInfo.Item);
+            if (!response.IsSuccessStatusCode)
+            {
+                throw new HttpRequestException($"Status update failed with code {(int)response.StatusCode}.");
+            }
+
+            var updatedStory = await response.Content.ReadFromJsonAsync<Story>();
+            if (updatedStory is not null)
+            {
+                var index = Items.FindIndex(i => i.Id == updatedStory.Id);
+                if (index >= 0)
+                {
+                    Items[index] = updatedStory;
+                }
+            }
+        }
+        catch
+        {
+            // Revert local status if backend update fails so UI and data stay consistent.
+            dropInfo.Item.Status = originalStatus;
+            _moveStoryErrorMessage = "Could not save the status change. The card was returned to its previous column.";
+        }
     }
 
     private void OpenStoryDetails(Story story)

--- a/ScrumPilot.Web/Pages/ScrumBoard.razor
+++ b/ScrumPilot.Web/Pages/ScrumBoard.razor
@@ -241,6 +241,9 @@
 
     private async Task OnItemDropped(MudItemDropInfo<Story> dropInfo)
     {
+        if (dropInfo.Item is null)
+            return;
+
         // Dropzone identifiers are: "ToDo", "InProgress", "Done"
         if (!Enum.TryParse<StoryStatus>(dropInfo.DropzoneIdentifier, out var newStatus))
         {


### PR DESCRIPTION
# Pull Request
**Pull request for Feature #94** 
## Description
Adds functionality to the Scrum board page where the update stories endpoint is hit, allowing for changing of status to affect the database. Confirmed that changes hit the endpoint and update the database accordingly. Changed the main story function to an Async function since we want the UI to work while loading the database. 

Implemented Error handling that gives errors for each failure case (Unable to load, Unable to move story). Upon error, the card is moved back to its existing column so the UI stays consistent.
<img width="1378" height="815" alt="image" src="https://github.com/user-attachments/assets/a8668ff6-a5a2-402a-9878-9f8795d653b3" />

## Related Issues
Closes #94 

## Checklist
- [ ] No tests needed as UI change and endpoint already has test cases
- [ ] Functionality of stories loading stays consistent with the previous versions of the page
- [ ] No compile errors present
- [ ] Confirmed that stories persist in the respective column on refresh and reload
- [ ] Confirmed HTTP endpoint is being hit in the terminal
- [ ] CI Workflow complete and no fails