### PR TITLE
Rename GenerateAiStory list overload to GenerateAiStories

### DIFF
--- a/ScrumPilot.API/Controllers/StoryController.cs
+++ b/ScrumPilot.API/Controllers/StoryController.cs
@@ -31,7 +31,7 @@ namespace ScrumPilot.API.Controllers
         }
 
         [HttpPost("generateAiStories")]
-        public async Task<ActionResult<List<Story>>> GenerateAiStory([FromBody] List<string> problemStatements)
+        public async Task<ActionResult<List<Story>>> GenerateAiStories([FromBody] List<string> problemStatements)
         {
             if (problemStatements == null || problemStatements.Count == 0)
             {

--- a/ScrumPilot.API/Services/IStoryService.cs
+++ b/ScrumPilot.API/Services/IStoryService.cs
@@ -6,7 +6,7 @@ namespace ScrumPilot.API.Services
     {
         Task<IEnumerable<Story>> GetAllStoriesAsync();
         Task<IEnumerable<Story>> GetDraftStoriesAsync();
-        Task<List<Story>> GenerateAiStory(List<string> problemStatements);
+        Task<List<Story>> GenerateAiStories(List<string> problemStatements);
 
         Task<Story> CreateStoryAsync(Story story);
         Task<Story> UpdateStoryAsync(Story story);

--- a/ScrumPilot.API/Services/StoryService.cs
+++ b/ScrumPilot.API/Services/StoryService.cs
@@ -75,7 +75,7 @@ namespace ScrumPilot.API.Services
             return story;
         }
 
-        public async Task<List<Story>> GenerateAiStory(List<string> problemStatements)
+        public async Task<List<Story>> GenerateAiStories(List<string> problemStatements)
         {
             var stories = new List<Story>();
 


### PR DESCRIPTION
Renamed the overloaded GenerateAiStory method that accepts a list of problem statements to GenerateAiStories to improve clarity and avoid ambiguity.

Changes
Renamed list-based method in service
Updated interface
Updated controller references
Result
Clear distinction between single and multiple story generation
Improved readability

Closes #91