### PR TITLE
Added Epic and Sprint tables, updated context,

### DIFF
--- a/ScrumPilot.Data/Context/ScrumPilotContext.cs
+++ b/ScrumPilot.Data/Context/ScrumPilotContext.cs
@@ -13,6 +13,8 @@ namespace ScrumPilot.Data.Context
         }
 
         public DbSet<ProductBacklogItem> Stories { get; set; }
+        public DbSet<Epic> Epics { get; set; }
+        public DbSet<Sprint> Sprints { get; set; }
         public DbSet<AudioTranscript> AudioTranscripts { get; set; }
         public DbSet<MessageTranscript> MessageTranscripts { get; set; }
 
@@ -31,6 +33,8 @@ namespace ScrumPilot.Data.Context
             {
                 entity.HasKey(e => e.PbiId);
                 entity.Property(e => e.PbiId).ValueGeneratedOnAdd();
+                entity.Property(e => e.EpicId).IsRequired(false);
+                entity.Property(e => e.SprintId).IsRequired(false);
                 entity.Property(e => e.Title).IsRequired().HasMaxLength(200);
                 entity.Property(e => e.Description).HasMaxLength(2000);
                 entity.Property(e => e.Type).HasConversion<string>();
@@ -39,6 +43,27 @@ namespace ScrumPilot.Data.Context
                 entity.Property(e => e.Origin).HasConversion<string>();
                 entity.Property(e => e.DateCreated).IsRequired();
                 entity.Property(e => e.LastUpdated).IsRequired();
+            });
+
+            modelBuilder.Entity<Epic>(entity =>
+            {
+                entity.ToTable("Epic");
+                entity.HasKey(e => e.EpicId);
+                entity.Property(e => e.EpicId).ValueGeneratedOnAdd();
+                entity.Property(e => e.Name).IsRequired();
+                entity.Property(e => e.DateCreated).IsRequired();
+            });
+
+            modelBuilder.Entity<Sprint>(entity =>
+            {
+                entity.ToTable("Sprint");
+                entity.HasKey(e => e.SprintId);
+                entity.Property(e => e.SprintId).ValueGeneratedOnAdd();
+                entity.Property(e => e.SprintGoal);
+                entity.Property(e => e.StartDate);
+                entity.Property(e => e.EndDate);
+                entity.Property(e => e.IsOpen);
+                entity.Property(e => e.DateClosed);
             });
 
             modelBuilder.Entity<AudioTranscript>(entity =>

--- a/ScrumPilot.Data/Migrations/20260410003820_AddEpicAndSprintTables.Designer.cs
+++ b/ScrumPilot.Data/Migrations/20260410003820_AddEpicAndSprintTables.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using ScrumPilot.Data.Context;
 
@@ -10,9 +11,11 @@ using ScrumPilot.Data.Context;
 namespace ScrumPilot.Data.Migrations
 {
     [DbContext(typeof(ScrumPilotContext))]
-    partial class ScrumPilotContextModelSnapshot : ModelSnapshot
+    [Migration("20260410003820_AddEpicAndSprintTables")]
+    partial class AddEpicAndSprintTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "10.0.5");

--- a/ScrumPilot.Data/Migrations/20260410003820_AddEpicAndSprintTables.cs
+++ b/ScrumPilot.Data/Migrations/20260410003820_AddEpicAndSprintTables.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace ScrumPilot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEpicAndSprintTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<int>(
+                name: "SprintId",
+                table: "Stories",
+                type: "INTEGER",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "EpicId",
+                table: "Stories",
+                type: "INTEGER",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "INTEGER");
+
+            migrationBuilder.CreateTable(
+                name: "Epic",
+                columns: table => new
+                {
+                    EpicId = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", nullable: false),
+                    DateCreated = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Epic", x => x.EpicId);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "Sprint",
+                columns: table => new
+                {
+                    SprintId = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    SprintGoal = table.Column<string>(type: "TEXT", nullable: true),
+                    StartDate = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    EndDate = table.Column<DateTime>(type: "TEXT", nullable: true),
+                    IsOpen = table.Column<bool>(type: "INTEGER", nullable: false),
+                    DateClosed = table.Column<DateTime>(type: "TEXT", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Sprint", x => x.SprintId);
+                });
+
+            migrationBuilder.InsertData(
+                table: "Epic",
+                columns: new[] { "EpicId", "Name", "DateCreated" },
+                values: new object[] { 1, "Scrum Board Filtering", new DateTime(2026, 4, 10, 0, 0, 0, DateTimeKind.Utc) });
+
+            migrationBuilder.InsertData(
+                table: "Sprint",
+                columns: new[] { "SprintId", "SprintGoal", "StartDate", "EndDate", "IsOpen", "DateClosed" },
+                values: new object[] { 1, "Enable scrum board story filtering by sprint and epic", new DateTime(2026, 4, 10, 0, 0, 0, DateTimeKind.Utc), new DateTime(2026, 4, 24, 0, 0, 0, DateTimeKind.Utc), true, null });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                table: "Epic",
+                keyColumn: "EpicId",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Sprint",
+                keyColumn: "SprintId",
+                keyValue: 1);
+
+            migrationBuilder.DropTable(
+                name: "Epic");
+
+            migrationBuilder.DropTable(
+                name: "Sprint");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "SprintId",
+                table: "Stories",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "EpicId",
+                table: "Stories",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "INTEGER",
+                oldNullable: true);
+        }
+    }
+}

--- a/ScrumPilot.Data/Seeders/DatabaseSeeder.cs
+++ b/ScrumPilot.Data/Seeders/DatabaseSeeder.cs
@@ -9,8 +9,54 @@ namespace ScrumPilot.Data.Seeders
     {
         public static void SeedDatabase(ScrumPilotContext context)
         {
+            SeedEpics(context);
+            SeedSprints(context);
             SeedStories(context);
             SeedMessageTranscripts(context);
+        }
+
+        private static void SeedEpics(ScrumPilotContext context)
+        {
+            if (context.Epics.Any())
+            {
+                Console.WriteLine("[SEEDER] Database already has epics, skipping seed.");
+                return;
+            }
+
+            Console.WriteLine("[SEEDER] Seeding epics...");
+
+            context.Epics.Add(new Epic
+            {
+                Name = "Scrum Board Filtering",
+                DateCreated = DateTime.UtcNow
+            });
+
+            context.SaveChanges();
+            Console.WriteLine("[SEEDER] Successfully seeded epics.");
+        }
+
+        private static void SeedSprints(ScrumPilotContext context)
+        {
+            if (context.Sprints.Any())
+            {
+                Console.WriteLine("[SEEDER] Database already has sprints, skipping seed.");
+                return;
+            }
+
+            Console.WriteLine("[SEEDER] Seeding sprints...");
+
+            var sprintStart = DateTime.UtcNow.Date;
+            context.Sprints.Add(new Sprint
+            {
+                SprintGoal = "Enable scrum board story filtering by sprint and epic",
+                StartDate = sprintStart,
+                EndDate = sprintStart.AddDays(14),
+                IsOpen = true,
+                DateClosed = null
+            });
+
+            context.SaveChanges();
+            Console.WriteLine("[SEEDER] Successfully seeded sprints.");
         }
 
         public static async Task SeedUsersAsync(UserManager<ApplicationUser> userManager, RoleManager<IdentityRole> roleManager)
@@ -75,10 +121,16 @@ namespace ScrumPilot.Data.Seeders
 
             Console.WriteLine("[SEEDER] Seeding stories...");
 
+            var seedEpicId = context.Epics.OrderBy(e => e.EpicId).Select(e => (int?)e.EpicId).FirstOrDefault();
+            var seedSprintId = context.Sprints.OrderBy(s => s.SprintId).Select(s => (int?)s.SprintId).FirstOrDefault();
+
             var stories = new[]
             {
                 new ProductBacklogItem
                 {
+                    Type = PbiType.Story,
+                    EpicId = seedEpicId,
+                    SprintId = seedSprintId,
                     Title = "User Authentication",
                     Description = "As a user, I want to be able to log in to the application so that I can access my personalized content.",
                     Status = PbiStatus.ToDo,
@@ -89,6 +141,9 @@ namespace ScrumPilot.Data.Seeders
                 },
                 new ProductBacklogItem
                 {
+                    Type = PbiType.Story,
+                    EpicId = seedEpicId,
+                    SprintId = seedSprintId,
                     Title = "Create User Profile",
                     Description = "As a user, I want to create and manage my profile so that I can personalize my experience.",
                     Status = PbiStatus.InProgress,
@@ -99,6 +154,9 @@ namespace ScrumPilot.Data.Seeders
                 },
                 new ProductBacklogItem
                 {
+                    Type = PbiType.Story,
+                    EpicId = null,
+                    SprintId = null,
                     Title = "Dashboard Analytics",
                     Description = "As an admin, I want to view analytics on the dashboard so that I can monitor system usage.",
                     Status = PbiStatus.Done,
@@ -109,6 +167,9 @@ namespace ScrumPilot.Data.Seeders
                 },
                 new ProductBacklogItem
                 {
+                    Type = PbiType.Task,
+                    EpicId = null,
+                    SprintId = seedSprintId,
                     Title = "Database Connection",
                     Description = "As an Admin, I need to be able to retrieve data from our Database.",
                     Status = PbiStatus.ToDo,

--- a/ScrumPilot.Shared/Models/Epic.cs
+++ b/ScrumPilot.Shared/Models/Epic.cs
@@ -1,0 +1,9 @@
+namespace ScrumPilot.Shared.Models
+{
+    public class Epic
+    {
+        public int EpicId { get; set; }
+        public required string Name { get; set; }
+        public DateTime DateCreated { get; set; }
+    }
+}

--- a/ScrumPilot.Shared/Models/ProductBacklogItem.cs
+++ b/ScrumPilot.Shared/Models/ProductBacklogItem.cs
@@ -4,8 +4,8 @@
     {
         public int PbiId { get; set; }
         public PbiType Type { get; set; }
-        public int EpicId { get; set; }
-        public int SprintId { get; set; }
+        public int? EpicId { get; set; }
+        public int? SprintId { get; set; }
         public required string Title { get; set; }
         public string Description { get; set; } = "";
         public PbiStatus Status { get; set; }

--- a/ScrumPilot.Shared/Models/Sprint.cs
+++ b/ScrumPilot.Shared/Models/Sprint.cs
@@ -1,0 +1,12 @@
+namespace ScrumPilot.Shared.Models
+{
+    public class Sprint
+    {
+        public int SprintId { get; set; }
+        public string? SprintGoal { get; set; }
+        public DateTime? StartDate { get; set; }
+        public DateTime? EndDate { get; set; }
+        public bool IsOpen { get; set; }
+        public DateTime? DateClosed { get; set; }
+    }
+}


### PR DESCRIPTION
# Pull Request
Pull request for issue 123
## Description
This pull request adds the functionality for a Sprint and Epic table to the database. Commit changes to the seeders and integration to support these new tables. Confirmed tables are built correctly in the database, and migrations are successful. 

Epic Table:
<img width="372" height="217" alt="Epic" src="https://github.com/user-attachments/assets/fd7076c0-e0f5-43c2-b46d-1bf497d72089" />

Sprint Table:
<img width="395" height="497" alt="Sprint" src="https://github.com/user-attachments/assets/55c5e4be-5185-4f20-8749-c62c7d1146cd" />

## Related Issues
Closes #123 

## Checklist
- [ ] Migrations updated
- [ ] Database builds without issues 
- [ ] Integration of tables without errors 
- [ ] Functionality stays persistant with previous build
- [ ] Linting passes