### PR TITLE
Sprint Summarization f. team filtering, thread output, and backfill command

### DIFF
--- a/discord-bot/chat-summarizer.js
+++ b/discord-bot/chat-summarizer.js
@@ -437,9 +437,9 @@ async function collectRecapSummaries(guild, start, end, teamName) {
   const results  = [];
 
   for (const msg of messages) {
-    const match = msg.content.match(/\[(.+?)\]/);
-    if (!match) continue;
-    if (teamName && match[1].toLowerCase() !== teamName.toLowerCase()) continue;
+    const match    = msg.content.match(/\[(.+?)\]/);
+    const category = match ? match[1] : 'Scrum Pilot'; // untagged = legacy Scrum Pilot recording
+    if (teamName && category.toLowerCase() !== teamName.toLowerCase()) continue;
 
     const attachment = msg.attachments.first();
     if (!attachment) continue;
@@ -531,39 +531,81 @@ async function postSprintSummary(guild, summaryText, start, end, teamName, sprin
   }
 }
 
+async function summarizeChunk(content, label, start, end) {
+  const prompt =
+    `Summarize the following Discord channel messages from ${start} through ${end}.\n` +
+    `Extract: decisions made, tasks mentioned, blockers raised, progress updates, and open questions.\n` +
+    `Be concise. Use bullet points. Ignore casual small talk.\n\n` +
+    `Channel: ${label}\n\n${content}`;
+
+  try {
+    const res = await Promise.race([
+      anthropic.messages.create({
+        model: 'claude-opus-4-6', max_tokens: 1024,
+        messages: [{ role: 'user', content: prompt }],
+      }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('Claude timeout')), 60000))
+    ]);
+    return res.content[0].text;
+  } catch (err) {
+    console.warn(`[SprintSummarizer] Claude chunk failed, trying GPT-4o-mini:`, err.message);
+    const res = await openai.chat.completions.create({
+      model: 'gpt-4o-mini', max_tokens: 1024,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    return res.choices[0].message.content;
+  }
+}
+
+async function sprintSummaryExists(guild, start, end, teamName) {
+  const channel = guild.channels.cache.find(
+    c => c.name === SPRINT_CHANNEL && c.isTextBased()
+  );
+  if (!channel) return false;
+
+  const teamLabel   = teamName  ? ` · ${teamName}`   : '';
+  const sprint      = SPRINT_SCHEDULE.find(s => s.start === start && s.end === end);
+  const sprintLabel = sprint ? `${sprint.name} · ` : '';
+  const headerText  = `## 🏁 ${sprintLabel}Sprint Summary${teamLabel}`;
+
+  const messages = await fetchMessagesInRange(channel, new Date(start));
+  return messages.some(m => m.content.startsWith(headerText));
+}
+
 async function runSprintSummary(guild, start, end, teamName = null) {
   if (teamName && SPRINT_EXCLUDE_TEAMS.has(teamName)) {
     console.log(`[SprintSummarizer] Skipping excluded team: ${teamName}`);
     return;
   }
 
+  if (await sprintSummaryExists(guild, start, end, teamName)) {
+    console.log(`[SprintSummarizer] Already summarized ${start} → ${end}${teamName ? ` (team: ${teamName})` : ''} — skipping.`);
+    return;
+  }
+
   console.log(`[SprintSummarizer] Collecting ${start} → ${end}` + (teamName ? ` (team: ${teamName})` : '') + '...');
 
-  let [chatItems, recapItems] = await Promise.all([
-    collectChatSummaries(guild, start, end, teamName),
+  const [chatItems, recapItems] = await Promise.all([
+    collectRawMessages(guild, start, end, teamName),
     collectRecapSummaries(guild, start, end, teamName),
   ]);
-
-  if (chatItems.length === 0 && teamName) {
-    console.log(`[SprintSummarizer] No summaries found for ${teamName}, falling back to raw messages.`);
-    chatItems = await collectRawMessages(guild, start, end, teamName);
-  }
 
   console.log(`[SprintSummarizer] ${chatItems.length} chat item(s), ${recapItems.length} recap file(s).`);
 
   const outChannel = guild.channels.cache.find(c => c.name === SPRINT_CHANNEL && c.isTextBased());
   if (!outChannel) { console.error(`[SprintSummarizer] #${SPRINT_CHANNEL} not found.`); return; }
 
-  const allItems = [...chatItems, ...recapItems];
+const allItems = [...chatItems, ...recapItems];
   if (allItems.length === 0) {
     await outChannel.send(`_No summary data found for ${start} → ${end}${teamName ? ` (team: ${teamName})` : ''}._`);
     return;
   }
 
   const teamLabel = teamName ? ` for team **${teamName}**` : '';
-  const prompt = [
+
+  const buildPrompt = (items) => [
     `You are producing a Sprint Summary${teamLabel} covering ${start} through ${end}.`,
-    `The following are daily chat summaries and standup meeting recaps from that period.`,
+    `The following are raw channel messages and standup meeting recaps from that period.`,
     `Synthesize them into a concise, well-structured sprint roll-up.`,
     ``,
     `Include these sections (skip any with no data):`,
@@ -578,23 +620,49 @@ async function runSprintSummary(guild, start, end, teamName = null) {
     ``,
     `---`,
     ``,
-    ...allItems.flatMap(({ label, content }) => [`## ${label}`, '', content.trim(), '', '---', '']),
+    ...items.flatMap(({ label, content }) => [`## ${label}`, '', content.trim(), '', '---', '']),
   ].join('\n');
+
+  const callAI = async (prompt) => {
+    try {
+      const res = await Promise.race([
+        anthropic.messages.create({
+          model: 'claude-opus-4-6', max_tokens: 2048,
+          messages: [{ role: 'user', content: prompt }],
+        }),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('Claude timeout')), 60000))
+      ]);
+      return res.content[0].text;
+    } catch (err) {
+      console.warn('[SprintSummarizer] Claude failed, falling back to GPT-4o-mini:', err.message);
+      const res = await openai.chat.completions.create({
+        model: 'gpt-4o-mini', max_tokens: 2048,
+        messages: [{ role: 'user', content: prompt }],
+      });
+      return res.choices[0].message.content;
+    }
+  };
 
   let summary;
   try {
-    const res = await anthropic.messages.create({
-      model: 'claude-opus-4-6', max_tokens: 2048,
-      messages: [{ role: 'user', content: prompt }],
-    });
-    summary = res.content[0].text;
+    summary = await callAI(buildPrompt(allItems));
   } catch (err) {
-    console.warn('[SprintSummarizer] Claude failed, falling back to GPT-4o-mini:', err.message);
-    const res = await openai.chat.completions.create({
-      model: 'gpt-4o-mini', max_tokens: 2048,
-      messages: [{ role: 'user', content: prompt }],
-    });
-    summary = res.choices[0].message.content;
+    if (err.status === 429 || err.code === 'rate_limit_exceeded' || err.message?.includes('tokens') || err.message?.includes('too large')) {
+      console.warn('[SprintSummarizer] Token limit hit, switching to chunked pre-summarization...');
+      const chunkedItems = [];
+      for (const item of allItems) {
+        try {
+          const chunked = await summarizeChunk(item.content, item.label, start, end);
+          chunkedItems.push({ label: item.label, content: chunked });
+        } catch (chunkErr) {
+          console.warn(`[SprintSummarizer] Chunk failed for ${item.label}, using truncated raw:`, chunkErr.message);
+          chunkedItems.push({ label: item.label, content: item.content.slice(-8000) });
+        }
+      }
+      summary = await callAI(buildPrompt(chunkedItems));
+    } else {
+      throw err;
+    }
   }
 
   const sprint = SPRINT_SCHEDULE.find(s => s.start === start && s.end === end);
@@ -669,7 +737,10 @@ async function handleSprintCommand(message) {
       await runSprintSummary(message.guild, start, end, teamName);
     } catch (err) {
       console.error('[SprintSummarizer] Error:', err);
-      await message.reply(`❌ ${err.message}`);
+      const safeMsg = err.message?.includes('org-')
+        ? 'API rate limit or token limit exceeded. Check the console for details.'
+        : err.message;
+      await message.reply(`❌ ${safeMsg}`);
     }
     return true;
   }
@@ -681,7 +752,10 @@ async function handleSprintCommand(message) {
       await message.reply('✅ Sprint backfill complete.');
     } catch (err) {
       console.error('[SprintSummarizer] Backfill error:', err);
-      await message.reply(`❌ ${err.message}`);
+      const safeMsg = err.message?.includes('org-') 
+        ? 'API rate limit or token limit exceeded. Check the console for details.'
+        : err.message;
+      await message.reply(`❌ ${safeMsg}`);
     }
     return true;
   }

--- a/discord-bot/chat-summarizer.js
+++ b/discord-bot/chat-summarizer.js
@@ -3,6 +3,7 @@ const { ChannelType } = require('discord.js');
 const cron = require('node-cron');
 const fs = require('fs');
 const path = require('path');
+const https = require('https');
 const Anthropic = require('@anthropic-ai/sdk');
 const OpenAI = require('openai');
 
@@ -11,16 +12,31 @@ const OpenAI = require('openai');
 const CHAT_SUMMARIES_CHANNEL = process.env.CHAT_SUMMARIES_CHANNEL || 'chat-summaries';
 const SUMMARIES_DIR          = path.resolve(process.env.SUMMARIES_DIR || './summaries');
 const CHAT_SUMMARY_CRON      = process.env.CHAT_SUMMARY_CRON || '0 2 * * *';
+const SPRINT_SUMMARY_CRON = process.env.SPRINT_SUMMARY_CRON || '30 2 * * *';
+const RECAP_CHANNEL  = process.env.RECAP_CHANNEL  || 'standup-recap';
+const SPRINT_CHANNEL = process.env.SPRINT_CHANNEL || RECAP_CHANNEL;
 const STATE_FILE             = path.join(__dirname, 'chat-state.json');
+const SPRINT_EXCLUDE_TEAMS = new Set(
+  (process.env.SPRINT_EXCLUDE_TEAMS || '').split(',').map(s => s.trim()).filter(Boolean)
+);
 
 const SKIP_CHANNELS = new Set([
   CHAT_SUMMARIES_CHANNEL,
   process.env.RECAP_CHANNEL || 'standup-recap',
   process.env.BOT_COMMANDS  || 'bot-commands',
+  process.env.SPRINT_CHANNEL   || 'scrumlord-generated-sprint-recaps',
 ]);
 
 const anthropic = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY });
 const openai    = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const SPRINT_SCHEDULE = [
+  { name: 'Sprint 1', start: '2026-02-15', end: '2026-02-28' },
+  { name: 'Sprint 2', start: '2026-03-01', end: '2026-03-21' },
+  { name: 'Sprint 3', start: '2026-03-22', end: '2026-04-04' },
+  { name: 'Sprint 4', start: '2026-04-05', end: '2026-04-18' },
+  { name: 'Sprint 5', start: '2026-04-19', end: '2026-05-02' },
+];
 
 // ─── Moved from index.js ──────────────────────────────────────────────────────
 
@@ -235,7 +251,7 @@ async function summarizeChannel(channel, sinceDate, outputChannel) {
 
     try {
       await outputChannel.send({
-        content: `📄 Chat summary: **#${channelName}** — ${dateStr}`,
+        content: `📄 Chat summary: **#${channelName}** [${channel.parent?.name || 'uncategorized'}] — ${dateStr}`,
         files:   [filePath],
       });
     } catch (err) {
@@ -305,6 +321,374 @@ async function runSummarizer(client) {
   console.log('[ChatSummarizer] Run complete.');
 }
 
+// ═══════════════════════════════════════════════════════════════════════════════
+// SPRINT SUMMARIZATION
+// Commands: !sprintsummary <YYYY-MM-DD> <YYYY-MM-DD> [--team <TeamName>]
+//           !listteams
+// ═══════════════════════════════════════════════════════════════════════════════
+
+function isValidDate(str) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(str) && !isNaN(Date.parse(str));
+}
+
+function estDateOf(message) {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: 'America/New_York' })
+    .format(new Date(message.createdTimestamp));
+}
+
+function isInRange(dateStr, start, end) {
+  return dateStr >= start && dateStr <= end;
+}
+
+function downloadAttachment(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, res => {
+      let data = '';
+      res.on('data',  chunk => { data += chunk; });
+      res.on('end',   ()    => resolve(data));
+      res.on('error', reject);
+    }).on('error', reject);
+  });
+}
+
+// Paginate a summary channel within a closed [start, end] date window.
+// Different from fetchMessagesInRange which uses an open sinceDate.
+async function fetchSummaryMessagesInRange(channel, start, end) {
+  const results = [];
+  let   lastId  = null;
+  const stopMs  = Date.parse(start);
+
+  while (true) {
+    const options = { limit: 100 };
+    if (lastId) options.before = lastId;
+
+    let batch;
+    try { batch = await channel.messages.fetch(options); }
+    catch (err) {
+      console.warn(`[SprintSummarizer] Fetch error on #${channel.name}:`, err.message);
+      break;
+    }
+
+    if (batch.size === 0) break;
+    const msgs = [...batch.values()];
+
+    for (const msg of msgs) {
+      if (msg.createdTimestamp < stopMs) return results.reverse();
+      if (isInRange(estDateOf(msg), start, end)) results.push(msg);
+    }
+
+    if (batch.size < 100) break;
+    lastId = msgs[msgs.length - 1].id;
+    await new Promise(r => setTimeout(r, 300));
+  }
+
+  return results.reverse();
+}
+
+// Collect chat summary attachments from #chat-summaries.
+// Message format: "📄 Chat summary: **#text** [Scrum Pilot] — 2026-04-15"
+async function collectChatSummaries(guild, start, end, teamName) {
+  const channel = guild.channels.cache.find(
+    c => c.name === CHAT_SUMMARIES_CHANNEL && c.isTextBased()
+  );
+  if (!channel) {
+    console.warn(`[SprintSummarizer] #${CHAT_SUMMARIES_CHANNEL} not found.`);
+    return [];
+  }
+
+  const since = new Date(start);
+  since.setDate(since.getDate() - 1);
+  const allMessages = await fetchMessagesInRange(channel, since);
+  const results  = [];
+
+  for (const msg of allMessages) {
+    const dateMatch = msg.content.match(/—\s*(\d{4}-\d{2}-\d{2})/);
+    if (!dateMatch || !isInRange(dateMatch[1], start, end)) continue;
+
+    const teamMatch = msg.content.match(/\[(.+?)\]/);
+    if (teamName && teamMatch &&teamMatch[1].toLowerCase() !== teamName.toLowerCase()) continue;
+
+    const attachment = msg.attachments.first();
+    if (!attachment) continue;
+
+    try {
+      const content = await downloadAttachment(attachment.url);
+      results.push({ label: msg.content.split('\n')[0], content });
+    } catch (err) {
+      console.warn(`[SprintSummarizer] Could not download chat summary:`, err.message);
+    }
+  }
+
+  return results;
+}
+
+// Collect standup recap attachments from #standup-recap.
+// Message format: "📋 Meeting recap from <date> [Scrum Pilot]"
+async function collectRecapSummaries(guild, start, end, teamName) {
+  const channel = guild.channels.cache.find(
+    c => c.name === RECAP_CHANNEL && c.isTextBased()
+  );
+  if (!channel) {
+    console.warn(`[SprintSummarizer] #${RECAP_CHANNEL} not found.`);
+    return [];
+  }
+
+  const messages = await fetchSummaryMessagesInRange(channel, start, end);
+  const results  = [];
+
+  for (const msg of messages) {
+    const match = msg.content.match(/\[(.+?)\]/);
+    if (!match) continue;
+    if (teamName && match[1].toLowerCase() !== teamName.toLowerCase()) continue;
+
+    const attachment = msg.attachments.first();
+    if (!attachment) continue;
+
+    try {
+      const content = await downloadAttachment(attachment.url);
+      results.push({ label: msg.content.split('\n')[0], content });
+    } catch (err) {
+      console.warn(`[SprintSummarizer] Could not download recap:`, err.message);
+    }
+  }
+
+  return results;
+}
+
+async function collectRawMessages(guild, start, end, teamName) {
+  const results = [];
+  const since   = new Date(start);
+  const until   = new Date(end);
+  until.setDate(until.getDate() + 1);
+
+  const teamChannels = guild.channels.cache.filter(
+    c => c.isTextBased() &&
+         c.type === ChannelType.GuildText &&
+         !SKIP_CHANNELS.has(c.name) &&
+         c.parent?.name?.toLowerCase() === teamName?.toLowerCase()
+  );
+
+  for (const [, channel] of teamChannels) {
+    const messages = await fetchMessagesInRange(channel, since);
+    const filtered = messages.filter(m => new Date(m.createdTimestamp) <= until);
+    if (filtered.length === 0) continue;
+
+    const text = (await Promise.all(
+      filtered
+        .filter(m => !m.author.bot && m.content.trim())
+        .map(async m => {
+          const member      = await m.guild.members.fetch(m.author.id).catch(() => null);
+          const displayName = member?.nickname || m.author.displayName || m.author.username;
+          return `[${estDateOf(m)}] [${displayName}]: ${m.content}`;
+        })
+    )).join('\n');
+
+    if (text.trim()) {
+      results.push({ label: `Raw messages: #${channel.name} (${teamName})`, content: text });
+    }
+  }
+
+  return results;
+}
+
+// Team names come from Discord category structure — no .env config needed.
+function getTeamNames(guild) {
+  const names = new Set();
+  guild.channels.cache.forEach(c => { if (c.parent?.name) names.add(c.parent.name); });
+  return [...names].sort();
+}
+
+async function postSprintSummary(guild, summaryText, start, end, teamName, sprintName = null) {
+  const channel = guild.channels.cache.find(
+    c => c.name === SPRINT_CHANNEL && c.isTextBased()
+  );
+  if (!channel) {
+    console.error(`[SprintSummarizer] Output channel #${SPRINT_CHANNEL} not found.`);
+    return;
+  }
+
+  const teamLabel   = teamName  ? ` · ${teamName}`   : '';
+  const sprintLabel = sprintName ? `${sprintName} · ` : '';
+  const header      = `## 🏁 ${sprintLabel}Sprint Summary${teamLabel}\n**${start} → ${end}**`;
+
+  const headerMsg = await channel.send(header);
+  const thread    = await headerMsg.startThread({
+    name: `${sprintLabel}${teamName || 'All Teams'} · ${start} → ${end}`,
+    autoArchiveDuration: 10080,
+  });
+
+  const LIMIT = 1950;
+  let remaining = summaryText;
+  while (remaining.length > 0) {
+    let cutAt = LIMIT;
+    if (remaining.length > LIMIT) {
+      const nl = remaining.lastIndexOf('\n', LIMIT);
+      if (nl > LIMIT / 2) cutAt = nl + 1;
+    }
+    await thread.send(remaining.slice(0, cutAt));
+    remaining = remaining.slice(cutAt);
+    if (remaining.length > 0) await new Promise(r => setTimeout(r, 500));
+  }
+}
+
+async function runSprintSummary(guild, start, end, teamName = null) {
+  if (teamName && SPRINT_EXCLUDE_TEAMS.has(teamName)) {
+    console.log(`[SprintSummarizer] Skipping excluded team: ${teamName}`);
+    return;
+  }
+
+  console.log(`[SprintSummarizer] Collecting ${start} → ${end}` + (teamName ? ` (team: ${teamName})` : '') + '...');
+
+  let [chatItems, recapItems] = await Promise.all([
+    collectChatSummaries(guild, start, end, teamName),
+    collectRecapSummaries(guild, start, end, teamName),
+  ]);
+
+  if (chatItems.length === 0 && teamName) {
+    console.log(`[SprintSummarizer] No summaries found for ${teamName}, falling back to raw messages.`);
+    chatItems = await collectRawMessages(guild, start, end, teamName);
+  }
+
+  console.log(`[SprintSummarizer] ${chatItems.length} chat item(s), ${recapItems.length} recap file(s).`);
+
+  const outChannel = guild.channels.cache.find(c => c.name === SPRINT_CHANNEL && c.isTextBased());
+  if (!outChannel) { console.error(`[SprintSummarizer] #${SPRINT_CHANNEL} not found.`); return; }
+
+  const allItems = [...chatItems, ...recapItems];
+  if (allItems.length === 0) {
+    await outChannel.send(`_No summary data found for ${start} → ${end}${teamName ? ` (team: ${teamName})` : ''}._`);
+    return;
+  }
+
+  const teamLabel = teamName ? ` for team **${teamName}**` : '';
+  const prompt = [
+    `You are producing a Sprint Summary${teamLabel} covering ${start} through ${end}.`,
+    `The following are daily chat summaries and standup meeting recaps from that period.`,
+    `Synthesize them into a concise, well-structured sprint roll-up.`,
+    ``,
+    `Include these sections (skip any with no data):`,
+    `1. **Sprint Overview** — What was this sprint focused on?`,
+    `2. **Key Accomplishments** — Concrete work completed, grouped by theme.`,
+    `3. **Blockers & Risks** — Any blockers raised, escalated, or unresolved.`,
+    `4. **Carry-over Items** — Work started but not finished.`,
+    `5. **Notable Decisions** — Key decisions made or milestones hit.`,
+    `6. **Participation Notes** — Who was active; notable async contributions.`,
+    ``,
+    `Be concise. Use bullet points. Synthesize — do not repeat the raw summaries.`,
+    ``,
+    `---`,
+    ``,
+    ...allItems.flatMap(({ label, content }) => [`## ${label}`, '', content.trim(), '', '---', '']),
+  ].join('\n');
+
+  let summary;
+  try {
+    const res = await anthropic.messages.create({
+      model: 'claude-opus-4-6', max_tokens: 2048,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    summary = res.content[0].text;
+  } catch (err) {
+    console.warn('[SprintSummarizer] Claude failed, falling back to GPT-4o-mini:', err.message);
+    const res = await openai.chat.completions.create({
+      model: 'gpt-4o-mini', max_tokens: 2048,
+      messages: [{ role: 'user', content: prompt }],
+    });
+    summary = res.choices[0].message.content;
+  }
+
+  const sprint = SPRINT_SCHEDULE.find(s => s.start === start && s.end === end);
+  await postSprintSummary(guild, summary, start, end, teamName, sprint?.name || null);
+}
+
+async function runAllSprintSummaries(guild) {
+  const today   = new Date().toISOString().slice(0, 10);
+  const teams   = getTeamNames(guild).filter(t => !SPRINT_EXCLUDE_TEAMS.has(t));
+  const sprints = SPRINT_SCHEDULE.filter(s => s.end <= today);
+
+  console.log(`[SprintSummarizer] Backfill: ${sprints.length} sprint(s), ${teams.length} team(s).`);
+
+  for (const sprint of sprints) {
+    for (const team of teams) {
+      console.log(`[SprintSummarizer] ${sprint.name} — ${team}`);
+      await runSprintSummary(guild, sprint.start, sprint.end, team);
+      await new Promise(r => setTimeout(r, 2000));
+    }
+  }
+
+  console.log('[SprintSummarizer] Backfill complete.');
+}
+async function handleSprintCommand(message) {
+  const content = message.content.trim();
+
+  if (content.startsWith('!listteams')) {
+    const teams = getTeamNames(message.guild);
+    if (teams.length === 0) {
+      await message.reply('No Discord categories found.');
+      return true;
+    }
+    await message.reply(`**Teams (from Discord categories):**\n${teams.map(t => `• ${t}`).join('\n')}`);
+    return true;
+  }
+
+  if (content.startsWith('!sprintsummary')) {
+    const args    = content.split(/\s+/).slice(1);
+    let teamName  = null;
+    const teamIdx = args.indexOf('--team');
+    if (teamIdx !== -1) {
+      teamName = args.slice(teamIdx + 1).join(' ') || null;
+      args.splice(teamIdx);
+    }
+
+    const [start, end] = args;
+
+    if (!start || !end) {
+      await message.reply(
+        '⚠️ Usage:\n' +
+        '`!sprintsummary <YYYY-MM-DD> <YYYY-MM-DD>`\n' +
+        '`!sprintsummary <YYYY-MM-DD> <YYYY-MM-DD> --team <TeamName>`\n\n' +
+        'Run `!listteams` to see available teams.'
+      );
+      return true;
+    }
+    if (!isValidDate(start) || !isValidDate(end)) {
+      await message.reply('❌ Dates must be in `YYYY-MM-DD` format.');
+      return true;
+    }
+    if (start > end) {
+      await message.reply('❌ Start date must be before end date.');
+      return true;
+    }
+
+    await message.reply(
+      `⏳ Generating sprint summary for **${start} → ${end}**` +
+      (teamName ? ` (team: **${teamName}**)` : '') + '...'
+    );
+
+    try {
+      await runSprintSummary(message.guild, start, end, teamName);
+    } catch (err) {
+      console.error('[SprintSummarizer] Error:', err);
+      await message.reply(`❌ ${err.message}`);
+    }
+    return true;
+  }
+
+  if (content.startsWith('!sprintbackfill')) {
+    await message.reply(`⏳ Running sprint summaries for all ${SPRINT_SCHEDULE.length} sprints across all teams...`);
+    try {
+      await runAllSprintSummaries(message.guild);
+      await message.reply('✅ Sprint backfill complete.');
+    } catch (err) {
+      console.error('[SprintSummarizer] Backfill error:', err);
+      await message.reply(`❌ ${err.message}`);
+    }
+    return true;
+  }
+
+  return false;
+}
+
 // ─── Exports ──────────────────────────────────────────────────────────────────
 
 module.exports = {
@@ -313,4 +697,10 @@ module.exports = {
   summarizeChannel,        // used by !summarize in index.js
   fetchMessagesInRange,    // used by !export in index.js
   formatMessagesToJson,    // used by !export in index.js
+  handleSprintCommand,
+  runSprintSummary,
+  runAllSprintSummaries,
+  SPRINT_SUMMARY_CRON,
+  SPRINT_SCHEDULE,
+  getTeamNames,
 };

--- a/discord-bot/index.js
+++ b/discord-bot/index.js
@@ -9,9 +9,15 @@ const cron = require('node-cron');
 const {
   runSummarizer,
   CHAT_SUMMARY_CRON,
+  SPRINT_SUMMARY_CRON,
   summarizeChannel,
   fetchMessagesInRange,
   formatMessagesToJson,
+  handleSprintCommand,
+  runSprintSummary,
+  runAllSprintSummaries,
+  SPRINT_SCHEDULE,
+  getTeamNames,
 } = require('./chat-summarizer');
 
 const client = new Client({
@@ -109,6 +115,27 @@ client.once(Events.ClientReady, (readyClient) => {
     );
   });
   console.log(`[ChatSummarizer] Scheduled daily at: ${CHAT_SUMMARY_CRON}`);
+
+  cron.schedule(SPRINT_SUMMARY_CRON, async () => {
+    try {
+      const yesterday = new Date();
+      yesterday.setDate(yesterday.getDate() - 1);
+      const dateStr = yesterday.toISOString().slice(0, 10);
+      const sprint = SPRINT_SCHEDULE.find(s => s.end === dateStr);
+      if (!sprint) return;
+
+      console.log(`[SprintSummarizer] Sprint end detected: ${sprint.name} — running summaries.`);
+      const guild = client.guilds.cache.first();
+      const teams = getTeamNames(guild);
+      for (const team of teams) {
+        await runSprintSummary(guild, sprint.start, sprint.end, team);
+        await new Promise(r => setTimeout(r, 2000));
+      }
+    } catch (err) {
+      console.error('[SprintSummarizer] Cron error:', err);
+    }
+  });
+  console.log(`[SprintSummarizer] Scheduled sprint end check at: ${SPRINT_SUMMARY_CRON}`);
 });
 
 client.on(Events.VoiceStateUpdate, (oldState, newState) => {
@@ -119,6 +146,8 @@ client.on(Events.VoiceStateUpdate, (oldState, newState) => {
 client.on(Events.MessageCreate, async (message) => {
   // Ignore messages from bots (including itself)
   if (message.author.bot) return;
+
+  if (await handleSprintCommand(message)) return;
 
   const isCommand = message.content.startsWith('!');
   if (!isCommand) return;

--- a/discord-bot/recorder.js
+++ b/discord-bot/recorder.js
@@ -314,7 +314,7 @@ async function transcribeMultiTrack(guild, userRecordings, timestamp, recapChann
   fs.writeFileSync(markdownPath, markdownContent);
  
   await recapChannel.send({
-    content: `📋 Meeting recap from ${dateString}`,
+    content: `📋 Meeting recap from ${dateString} [${voiceChannel.parent?.name || 'uncategorized'}]`,
     files: [markdownPath]
   });
  

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
   "requires": true,
   "packages": {
     "": {
+      "dependencies": {
+        "node-cron": "^4.2.1"
+      },
       "devDependencies": {
         "jest": "^30.2.0"
       }
@@ -3335,6 +3338,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-cron": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
+      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "devDependencies": {
     "jest": "^30.2.0"
+  },
+  "dependencies": {
+    "node-cron": "^4.2.1"
   }
 }


### PR DESCRIPTION
## Description
Adds automated sprint roll-up summarization to Scrumlord. Integrated into `chat-summarizer.js`, the system collects raw chat messages from each team's category channels and standup recap attachments from `#standup-recap`, filters by team and date range, generates an AI summary (Claude with GPT-4o-mini fallback and chunked pre-summarization for large sprints), and posts it as a threaded message in a dedicated sprint recap channel. Duplicate detection prevents re-summarizing sprints that have already been processed. Team names are derived automatically from Discord category structure — no manual configuration required beyond `.env` excludes.

## Changes

### `chat-summarizer.js`
- Added `RECAP_CHANNEL`, `SPRINT_CHANNEL`, `SPRINT_EXCLUDE_TEAMS`, and `SPRINT_SUMMARY_CRON` constants
- Added `SPRINT_SCHEDULE` array defining Sprint 1–5 date ranges
- Added `https` require for attachment downloading
- Added `SPRINT_CHANNEL` to `SKIP_CHANNELS` to prevent raw message collection from reading the output channel
- Updated `summarizeChannel` to tag posted messages with Discord category name: `[CategoryName]`
- Added `fetchSummaryMessagesInRange` — paginator filtering by title date rather than post date
- Added `downloadAttachment` — fetches attachment content from a Discord CDN URL
- Added `collectChatSummaries` — reads summary attachments from `#chat-summaries`, filters by team tag and date range (retained but not used as primary source)
- Added `collectRecapSummaries` — reads recap attachments from `#standup-recap`, filters by team tag and date range; untagged legacy recaps are attributed to Scrum Pilot
- Added `collectRawMessages` — primary source; fetches raw channel messages directly from each team's category channels within the sprint date range
- Added `getTeamNames` — derives team names from Discord category structure
- Added `postSprintSummary` — posts header message to sprint channel and full content into a thread (7-day auto-archive)
- Added `summarizeChunk` — pre-summarizes individual channel content when token limits are hit, with 60s Claude timeout and GPT-4o-mini fallback
- Added `sprintSummaryExists` — checks the sprint channel for an existing matching summary before running, preventing duplicates on re-runs
- Added `runSprintSummary` — orchestrates collection, AI synthesis, duplicate check, and posting for a single sprint/team; includes chunked pre-summarization fallback on token limit errors
- Added `runAllSprintSummaries` — loops all completed sprints and non-excluded teams; skips already-summarized sprints
- Added `handleSprintCommand` — handles `!sprintsummary`, `!sprintbackfill`, and `!listteams` commands; sanitizes API error messages to prevent sensitive org IDs from being posted to Discord
- Updated `module.exports` with all new sprint exports

### `recorder.js`
- Updated `recapChannel.send` to include `[CategoryName]` tag in message content so sprint summarizer can filter recaps by team

### `index.js`
- Imported sprint exports from `chat-summarizer.js`
- Added sprint end cron job using `SPRINT_SUMMARY_CRON` — fires at 2:30 AM, checks if yesterday was a sprint end date, runs summaries for all non-excluded teams if so; wrapped in try/catch to prevent bot crash
- Wired `handleSprintCommand` into `MessageCreate` handler

## New `.env` variables
```
SPRINT_CHANNEL=scrumlord-generated-sprint-recaps
SPRINT_SUMMARY_CRON=30 2 * * *
SPRINT_EXCLUDE_TEAMS=Rules,General,Smart Posture,discussion,scrumlord-generated-sprint-recaps
```

## Commands
- `!sprintsummary <YYYY-MM-DD> <YYYY-MM-DD>` — generate sprint summary for all teams
- `!sprintsummary <YYYY-MM-DD> <YYYY-MM-DD> --team <TeamName>` — scope to a specific team
- `!sprintbackfill` — generate summaries for all completed sprints across all teams; skips already-summarized sprints
- `!listteams` — list all teams derived from Discord category structure

## Testing
- Run `!listteams` and verify team names match Discord categories minus excluded teams
- Run `!sprintsummary <start> <end> --team <TeamName>` and verify thread is created in `#scrumlord-generated-sprint-recaps`
- Run `!sprintbackfill` and verify one thread per completed sprint per team
- Run `!sprintbackfill` a second time and verify all sprints are skipped as already summarized
- Confirm excluded teams produce no output
- Confirm `#scrumlord-generated-sprint-recaps` does not appear in raw message collection
- Restart bot and verify sprint end cron is scheduled in console output
- Verify API errors posted to Discord do not contain org IDs

## Related Issues
Closes #168

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Linting passes