### PR TITLE
Feature/124-Scrum-Board-Filtering-Backend

### DIFF
--- a/ScrumPilot.API/Controllers/EpicController.cs
+++ b/ScrumPilot.API/Controllers/EpicController.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using ScrumPilot.API.Services;
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class EpicController : ControllerBase
+    {
+        private readonly IEpicService _epicService;
+
+        public EpicController(IEpicService epicService)
+        {
+            _epicService = epicService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Epic>>> GetAllEpics()
+        {
+            var epics = await _epicService.GetAllEpicsAsync();
+            return Ok(epics);
+        }
+    }
+}

--- a/ScrumPilot.API/Controllers/PbiController.cs
+++ b/ScrumPilot.API/Controllers/PbiController.cs
@@ -31,9 +31,20 @@ namespace ScrumPilot.API.Controllers
         //}
 
         [HttpGet("getNonDraftPbis")]
-        public async Task<ActionResult<IEnumerable<ProductBacklogItem>>> GetNonDraftPbis()
+        public async Task<ActionResult<IEnumerable<ProductBacklogItem>>> GetNonDraftPbis(
+            [FromQuery] int? sprintId, [FromQuery] int? epicId)
         {
-            var pbis = await _pbiService.GetNonDraftPbisAsync();
+            IEnumerable<ProductBacklogItem> pbis;
+
+            if (sprintId.HasValue || epicId.HasValue)
+            {
+                pbis = await _pbiService.GetFilteredPbisAsync(sprintId, epicId);
+            }
+            else
+            {
+                pbis = await _pbiService.GetNonDraftPbisAsync();
+            }
+
             return Ok(pbis);
         }
 

--- a/ScrumPilot.API/Controllers/SprintController.cs
+++ b/ScrumPilot.API/Controllers/SprintController.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using ScrumPilot.API.Services;
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class SprintController : ControllerBase
+    {
+        private readonly ISprintService _sprintService;
+
+        public SprintController(ISprintService sprintService)
+        {
+            _sprintService = sprintService;
+        }
+
+        [HttpGet]
+        public async Task<ActionResult<IEnumerable<Sprint>>> GetAllSprints()
+        {
+            var sprints = await _sprintService.GetAllSprintsAsync();
+            return Ok(sprints);
+        }
+    }
+}

--- a/ScrumPilot.API/Program.cs
+++ b/ScrumPilot.API/Program.cs
@@ -43,6 +43,8 @@ builder.Services.AddAuthorizationBuilder()
 
 // Add services to the container.
 builder.Services.AddScoped<IPbiService, PbiService>();
+builder.Services.AddScoped<ISprintService, SprintService>();
+builder.Services.AddScoped<IEpicService, EpicService>();
 builder.Services.AddHttpClient<PbiService>(client =>
 {
     client.Timeout = TimeSpan.FromMinutes(5);

--- a/ScrumPilot.API/Services/EpicService.cs
+++ b/ScrumPilot.API/Services/EpicService.cs
@@ -1,0 +1,20 @@
+using ScrumPilot.Data.Repositories;
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.API.Services
+{
+    public class EpicService : IEpicService
+    {
+        private readonly IEpicRepository _epicRepository;
+
+        public EpicService(IEpicRepository epicRepository)
+        {
+            _epicRepository = epicRepository;
+        }
+
+        public async Task<IEnumerable<Epic>> GetAllEpicsAsync()
+        {
+            return await _epicRepository.GetAllEpicsAsync();
+        }
+    }
+}

--- a/ScrumPilot.API/Services/IEpicService.cs
+++ b/ScrumPilot.API/Services/IEpicService.cs
@@ -1,0 +1,9 @@
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.API.Services
+{
+    public interface IEpicService
+    {
+        Task<IEnumerable<Epic>> GetAllEpicsAsync();
+    }
+}

--- a/ScrumPilot.API/Services/IPbiService.cs
+++ b/ScrumPilot.API/Services/IPbiService.cs
@@ -14,6 +14,7 @@ namespace ScrumPilot.API.Services
         Task<IEnumerable<ProductBacklogItem>> GetAllPbisAsync();
         Task<IEnumerable<ProductBacklogItem>> GetDraftPbisAsync();
         Task<IEnumerable<ProductBacklogItem>> GetNonDraftPbisAsync();
+        Task<IEnumerable<ProductBacklogItem>> GetFilteredPbisAsync(int? sprintId, int? epicId);
         Task<ProductBacklogItem> UpdatePbiAsync(ProductBacklogItem pbi);
     }
 }

--- a/ScrumPilot.API/Services/ISprintService.cs
+++ b/ScrumPilot.API/Services/ISprintService.cs
@@ -1,0 +1,9 @@
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.API.Services
+{
+    public interface ISprintService
+    {
+        Task<IEnumerable<Sprint>> GetAllSprintsAsync();
+    }
+}

--- a/ScrumPilot.API/Services/PbiService.cs
+++ b/ScrumPilot.API/Services/PbiService.cs
@@ -37,6 +37,11 @@ namespace ScrumPilot.API.Services
             return await _pbiRepository.GetDraftPbisAsync();
         }
 
+        public async Task<IEnumerable<ProductBacklogItem>> GetFilteredPbisAsync(int? sprintId, int? epicId)
+        {
+            return await _pbiRepository.GetFilteredPbisAsync(sprintId, epicId);
+        }
+
         /// <summary>
         /// Generates a new AI-based Scrum user story from a given problem statement using the configured Ollama API.
         /// </summary>

--- a/ScrumPilot.API/Services/SprintService.cs
+++ b/ScrumPilot.API/Services/SprintService.cs
@@ -1,0 +1,20 @@
+using ScrumPilot.Data.Repositories;
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.API.Services
+{
+    public class SprintService : ISprintService
+    {
+        private readonly ISprintRepository _sprintRepository;
+
+        public SprintService(ISprintRepository sprintRepository)
+        {
+            _sprintRepository = sprintRepository;
+        }
+
+        public async Task<IEnumerable<Sprint>> GetAllSprintsAsync()
+        {
+            return await _sprintRepository.GetAllSprintsAsync();
+        }
+    }
+}

--- a/ScrumPilot.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/ScrumPilot.Data/Extensions/ServiceCollectionExtensions.cs
@@ -52,6 +52,8 @@ namespace ScrumPilot.Data.Extensions
             // Add repositories
             services.AddScoped<IPbiRepository, PbiRepository>();
             services.AddScoped<ICommentRepository, CommentRepository>();
+            services.AddScoped<ISprintRepository, SprintRepository>();
+            services.AddScoped<IEpicRepository, EpicRepository>();
 
             return services;
         }

--- a/ScrumPilot.Data/Repositories/EpicRepository.cs
+++ b/ScrumPilot.Data/Repositories/EpicRepository.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using ScrumPilot.Data.Context;
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.Data.Repositories
+{
+    public class EpicRepository : IEpicRepository
+    {
+        private readonly ScrumPilotContext _context;
+
+        public EpicRepository(ScrumPilotContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Epic>> GetAllEpicsAsync()
+        {
+            return await _context.Epics
+                .OrderBy(e => e.Name)
+                .ToListAsync();
+        }
+    }
+}

--- a/ScrumPilot.Data/Repositories/IEpicRepository.cs
+++ b/ScrumPilot.Data/Repositories/IEpicRepository.cs
@@ -1,0 +1,9 @@
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.Data.Repositories
+{
+    public interface IEpicRepository
+    {
+        Task<IEnumerable<Epic>> GetAllEpicsAsync();
+    }
+}

--- a/ScrumPilot.Data/Repositories/IPbiRepository.cs
+++ b/ScrumPilot.Data/Repositories/IPbiRepository.cs
@@ -11,6 +11,7 @@ namespace ScrumPilot.Data.Repositories
         Task<IEnumerable<ProductBacklogItem>> GetByStatusAsync(PbiStatus status);
         Task<IEnumerable<ProductBacklogItem>> GetDraftPbisAsync();
         Task<IEnumerable<ProductBacklogItem>> GetNonDraftPbisAsync();
+        Task<IEnumerable<ProductBacklogItem>> GetFilteredPbisAsync(int? sprintId, int? epicId);
         Task<ProductBacklogItem> UpdateAsync(ProductBacklogItem story);
     }
 }

--- a/ScrumPilot.Data/Repositories/ISprintRepository.cs
+++ b/ScrumPilot.Data/Repositories/ISprintRepository.cs
@@ -1,0 +1,9 @@
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.Data.Repositories
+{
+    public interface ISprintRepository
+    {
+        Task<IEnumerable<Sprint>> GetAllSprintsAsync();
+    }
+}

--- a/ScrumPilot.Data/Repositories/PbiRepository.cs
+++ b/ScrumPilot.Data/Repositories/PbiRepository.cs
@@ -85,5 +85,20 @@ namespace ScrumPilot.Data.Repositories
                 .OrderByDescending(s => s.DateCreated)
                 .ToListAsync();
         }
+
+        public async Task<IEnumerable<ProductBacklogItem>> GetFilteredPbisAsync(int? sprintId, int? epicId)
+        {
+            var query = _context.Stories.Where(s => !s.IsDraft);
+
+            if (sprintId.HasValue)
+                query = query.Where(s => s.SprintId == sprintId.Value);
+
+            if (epicId.HasValue)
+                query = query.Where(s => s.EpicId == epicId.Value);
+
+            return await query
+                .OrderByDescending(s => s.DateCreated)
+                .ToListAsync();
+        }
     }
 }

--- a/ScrumPilot.Data/Repositories/SprintRepository.cs
+++ b/ScrumPilot.Data/Repositories/SprintRepository.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore;
+using ScrumPilot.Data.Context;
+using ScrumPilot.Shared.Models;
+
+namespace ScrumPilot.Data.Repositories
+{
+    public class SprintRepository : ISprintRepository
+    {
+        private readonly ScrumPilotContext _context;
+
+        public SprintRepository(ScrumPilotContext context)
+        {
+            _context = context;
+        }
+
+        public async Task<IEnumerable<Sprint>> GetAllSprintsAsync()
+        {
+            return await _context.Sprints
+                .OrderByDescending(s => s.StartDate)
+                .ToListAsync();
+        }
+    }
+}

--- a/ScrumPilot.UnitTests/Backend/ControllerTests/EpicControllerTests.cs
+++ b/ScrumPilot.UnitTests/Backend/ControllerTests/EpicControllerTests.cs
@@ -1,0 +1,71 @@
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using ScrumPilot.API.Controllers;
+using ScrumPilot.API.Services;
+using ScrumPilot.Shared.Models;
+using Xunit;
+
+namespace ScrumPilot.UnitTests.Backend.ControllerTests
+{
+    public class EpicControllerTests
+    {
+        private readonly IEpicService _mockEpicService;
+        private readonly EpicController _controller;
+
+        public EpicControllerTests()
+        {
+            _mockEpicService = Substitute.For<IEpicService>();
+            _controller = new EpicController(_mockEpicService);
+        }
+
+        [Fact]
+        public async Task GetAllEpics_ReturnsOkResult_WithListOfEpics()
+        {
+            // Arrange
+            var expectedEpics = new List<Epic>
+            {
+                new Epic
+                {
+                    EpicId = 1,
+                    Name = "Scrum Board Filtering",
+                    DateCreated = DateTime.UtcNow
+                },
+                new Epic
+                {
+                    EpicId = 2,
+                    Name = "User Management",
+                    DateCreated = DateTime.UtcNow
+                }
+            };
+
+            _mockEpicService.GetAllEpicsAsync().Returns(expectedEpics);
+
+            // Act
+            var result = await _controller.GetAllEpics();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualEpics = Assert.IsType<List<Epic>>(okResult.Value);
+            Assert.Equal(expectedEpics.Count, actualEpics.Count);
+            Assert.Equal(expectedEpics, actualEpics);
+            await _mockEpicService.Received(1).GetAllEpicsAsync();
+        }
+
+        [Fact]
+        public async Task GetAllEpics_ReturnsOkResult_WithEmptyList_WhenNoEpics()
+        {
+            // Arrange
+            var expectedEpics = new List<Epic>();
+            _mockEpicService.GetAllEpicsAsync().Returns(expectedEpics);
+
+            // Act
+            var result = await _controller.GetAllEpics();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualEpics = Assert.IsType<List<Epic>>(okResult.Value);
+            Assert.Empty(actualEpics);
+            await _mockEpicService.Received(1).GetAllEpicsAsync();
+        }
+    }
+}

--- a/ScrumPilot.UnitTests/Backend/ControllerTests/SprintControllerTests.cs
+++ b/ScrumPilot.UnitTests/Backend/ControllerTests/SprintControllerTests.cs
@@ -1,0 +1,75 @@
+using Microsoft.AspNetCore.Mvc;
+using NSubstitute;
+using ScrumPilot.API.Controllers;
+using ScrumPilot.API.Services;
+using ScrumPilot.Shared.Models;
+using Xunit;
+
+namespace ScrumPilot.UnitTests.Backend.ControllerTests
+{
+    public class SprintControllerTests
+    {
+        private readonly ISprintService _mockSprintService;
+        private readonly SprintController _controller;
+
+        public SprintControllerTests()
+        {
+            _mockSprintService = Substitute.For<ISprintService>();
+            _controller = new SprintController(_mockSprintService);
+        }
+
+        [Fact]
+        public async Task GetAllSprints_ReturnsOkResult_WithListOfSprints()
+        {
+            // Arrange
+            var expectedSprints = new List<Sprint>
+            {
+                new Sprint
+                {
+                    SprintId = 1,
+                    SprintGoal = "Sprint 1 Goal",
+                    StartDate = DateTime.UtcNow,
+                    EndDate = DateTime.UtcNow.AddDays(14),
+                    IsOpen = true
+                },
+                new Sprint
+                {
+                    SprintId = 2,
+                    SprintGoal = "Sprint 2 Goal",
+                    StartDate = DateTime.UtcNow.AddDays(14),
+                    EndDate = DateTime.UtcNow.AddDays(28),
+                    IsOpen = false
+                }
+            };
+
+            _mockSprintService.GetAllSprintsAsync().Returns(expectedSprints);
+
+            // Act
+            var result = await _controller.GetAllSprints();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualSprints = Assert.IsType<List<Sprint>>(okResult.Value);
+            Assert.Equal(expectedSprints.Count, actualSprints.Count);
+            Assert.Equal(expectedSprints, actualSprints);
+            await _mockSprintService.Received(1).GetAllSprintsAsync();
+        }
+
+        [Fact]
+        public async Task GetAllSprints_ReturnsOkResult_WithEmptyList_WhenNoSprints()
+        {
+            // Arrange
+            var expectedSprints = new List<Sprint>();
+            _mockSprintService.GetAllSprintsAsync().Returns(expectedSprints);
+
+            // Act
+            var result = await _controller.GetAllSprints();
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualSprints = Assert.IsType<List<Sprint>>(okResult.Value);
+            Assert.Empty(actualSprints);
+            await _mockSprintService.Received(1).GetAllSprintsAsync();
+        }
+    }
+}

--- a/ScrumPilot.UnitTests/Backend/ControllerTests/StoryControllerTests.cs
+++ b/ScrumPilot.UnitTests/Backend/ControllerTests/StoryControllerTests.cs
@@ -487,5 +487,108 @@ namespace ScrumPilot.UnitTests.Backend.ControllerTests
             Assert.IsType<NotFoundResult>(result);
             await _mockPbiService.Received(1).DeletePbiAsync(pbiId);
         }
+
+        [Fact]
+        public async Task GetNonDraftPbis_NoFilters_ReturnsAllNonDraftPbis()
+        {
+            // Arrange
+            var expectedPbis = new List<ProductBacklogItem>
+            {
+                new ProductBacklogItem { PbiId = 1, Title = "PBI 1", IsDraft = false },
+                new ProductBacklogItem { PbiId = 2, Title = "PBI 2", IsDraft = false }
+            };
+            _mockPbiService.GetNonDraftPbisAsync().Returns(expectedPbis);
+
+            // Act
+            var result = await _controller.GetNonDraftPbis(null, null);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualPbis = Assert.IsType<List<ProductBacklogItem>>(okResult.Value);
+            Assert.Equal(2, actualPbis.Count);
+            await _mockPbiService.Received(1).GetNonDraftPbisAsync();
+            await _mockPbiService.DidNotReceive().GetFilteredPbisAsync(Arg.Any<int?>(), Arg.Any<int?>());
+        }
+
+        [Fact]
+        public async Task GetNonDraftPbis_WithSprintId_ReturnsFilteredPbis()
+        {
+            // Arrange
+            var expectedPbis = new List<ProductBacklogItem>
+            {
+                new ProductBacklogItem { PbiId = 1, Title = "PBI 1", SprintId = 1 }
+            };
+            _mockPbiService.GetFilteredPbisAsync(1, null).Returns(expectedPbis);
+
+            // Act
+            var result = await _controller.GetNonDraftPbis(1, null);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualPbis = Assert.IsType<List<ProductBacklogItem>>(okResult.Value);
+            Assert.Single(actualPbis);
+            await _mockPbiService.Received(1).GetFilteredPbisAsync(1, null);
+            await _mockPbiService.DidNotReceive().GetNonDraftPbisAsync();
+        }
+
+        [Fact]
+        public async Task GetNonDraftPbis_WithEpicId_ReturnsFilteredPbis()
+        {
+            // Arrange
+            var expectedPbis = new List<ProductBacklogItem>
+            {
+                new ProductBacklogItem { PbiId = 1, Title = "PBI 1", EpicId = 2 }
+            };
+            _mockPbiService.GetFilteredPbisAsync(null, 2).Returns(expectedPbis);
+
+            // Act
+            var result = await _controller.GetNonDraftPbis(null, 2);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualPbis = Assert.IsType<List<ProductBacklogItem>>(okResult.Value);
+            Assert.Single(actualPbis);
+            await _mockPbiService.Received(1).GetFilteredPbisAsync(null, 2);
+            await _mockPbiService.DidNotReceive().GetNonDraftPbisAsync();
+        }
+
+        [Fact]
+        public async Task GetNonDraftPbis_WithBothFilters_ReturnsAndFilteredPbis()
+        {
+            // Arrange
+            var expectedPbis = new List<ProductBacklogItem>
+            {
+                new ProductBacklogItem { PbiId = 1, Title = "PBI 1", SprintId = 1, EpicId = 2 }
+            };
+            _mockPbiService.GetFilteredPbisAsync(1, 2).Returns(expectedPbis);
+
+            // Act
+            var result = await _controller.GetNonDraftPbis(1, 2);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualPbis = Assert.IsType<List<ProductBacklogItem>>(okResult.Value);
+            Assert.Single(actualPbis);
+            Assert.Equal(1, actualPbis[0].SprintId);
+            Assert.Equal(2, actualPbis[0].EpicId);
+            await _mockPbiService.Received(1).GetFilteredPbisAsync(1, 2);
+        }
+
+        [Fact]
+        public async Task GetNonDraftPbis_WithFilters_ReturnsEmptyList_WhenNoMatch()
+        {
+            // Arrange
+            var expectedPbis = new List<ProductBacklogItem>();
+            _mockPbiService.GetFilteredPbisAsync(99, 99).Returns(expectedPbis);
+
+            // Act
+            var result = await _controller.GetNonDraftPbis(99, 99);
+
+            // Assert
+            var okResult = Assert.IsType<OkObjectResult>(result.Result);
+            var actualPbis = Assert.IsType<List<ProductBacklogItem>>(okResult.Value);
+            Assert.Empty(actualPbis);
+            await _mockPbiService.Received(1).GetFilteredPbisAsync(99, 99);
+        }
     }
 }

--- a/ScrumPilot.UnitTests/Backend/ServiceTests/EpicServiceTests.cs
+++ b/ScrumPilot.UnitTests/Backend/ServiceTests/EpicServiceTests.cs
@@ -1,0 +1,55 @@
+using NSubstitute;
+using ScrumPilot.API.Services;
+using ScrumPilot.Data.Repositories;
+using ScrumPilot.Shared.Models;
+using Xunit;
+
+namespace ScrumPilot.UnitTests.Backend.ServiceTests
+{
+    public class EpicServiceTests
+    {
+        private readonly IEpicRepository _mockRepository;
+        private readonly EpicService _epicService;
+
+        public EpicServiceTests()
+        {
+            _mockRepository = Substitute.For<IEpicRepository>();
+            _epicService = new EpicService(_mockRepository);
+        }
+
+        [Fact]
+        public async Task GetAllEpicsAsync_ReturnsEpicsFromRepository()
+        {
+            // Arrange
+            var expectedEpics = new List<Epic>
+            {
+                new Epic { EpicId = 1, Name = "Scrum Board Filtering", DateCreated = DateTime.UtcNow },
+                new Epic { EpicId = 2, Name = "User Management", DateCreated = DateTime.UtcNow }
+            };
+            _mockRepository.GetAllEpicsAsync().Returns(expectedEpics);
+
+            // Act
+            var result = await _epicService.GetAllEpicsAsync();
+
+            // Assert
+            var actualEpics = result.ToList();
+            Assert.Equal(expectedEpics.Count, actualEpics.Count);
+            Assert.Equal(expectedEpics, actualEpics);
+            await _mockRepository.Received(1).GetAllEpicsAsync();
+        }
+
+        [Fact]
+        public async Task GetAllEpicsAsync_ReturnsEmptyList_WhenNoEpics()
+        {
+            // Arrange
+            _mockRepository.GetAllEpicsAsync().Returns(new List<Epic>());
+
+            // Act
+            var result = await _epicService.GetAllEpicsAsync();
+
+            // Assert
+            Assert.Empty(result);
+            await _mockRepository.Received(1).GetAllEpicsAsync();
+        }
+    }
+}

--- a/ScrumPilot.UnitTests/Backend/ServiceTests/SprintServiceTests.cs
+++ b/ScrumPilot.UnitTests/Backend/ServiceTests/SprintServiceTests.cs
@@ -1,0 +1,69 @@
+using NSubstitute;
+using ScrumPilot.API.Services;
+using ScrumPilot.Data.Repositories;
+using ScrumPilot.Shared.Models;
+using Xunit;
+
+namespace ScrumPilot.UnitTests.Backend.ServiceTests
+{
+    public class SprintServiceTests
+    {
+        private readonly ISprintRepository _mockRepository;
+        private readonly SprintService _sprintService;
+
+        public SprintServiceTests()
+        {
+            _mockRepository = Substitute.For<ISprintRepository>();
+            _sprintService = new SprintService(_mockRepository);
+        }
+
+        [Fact]
+        public async Task GetAllSprintsAsync_ReturnsSprintsFromRepository()
+        {
+            // Arrange
+            var expectedSprints = new List<Sprint>
+            {
+                new Sprint
+                {
+                    SprintId = 1,
+                    SprintGoal = "Sprint 1 Goal",
+                    StartDate = DateTime.UtcNow,
+                    EndDate = DateTime.UtcNow.AddDays(14),
+                    IsOpen = true
+                },
+                new Sprint
+                {
+                    SprintId = 2,
+                    SprintGoal = "Sprint 2 Goal",
+                    StartDate = DateTime.UtcNow.AddDays(14),
+                    EndDate = DateTime.UtcNow.AddDays(28),
+                    IsOpen = false
+                }
+            };
+            _mockRepository.GetAllSprintsAsync().Returns(expectedSprints);
+
+            // Act
+            var result = await _sprintService.GetAllSprintsAsync();
+
+            // Assert
+            var actualSprints = result.ToList();
+            Assert.Equal(expectedSprints.Count, actualSprints.Count);
+            Assert.Equal(expectedSprints, actualSprints);
+            await _mockRepository.Received(1).GetAllSprintsAsync();
+        }
+
+        [Fact]
+        public async Task GetAllSprintsAsync_ReturnsEmptyList_WhenNoSprints()
+        {
+            // Arrange
+            _mockRepository.GetAllSprintsAsync().Returns(new List<Sprint>());
+
+            // Act
+            var result = await _sprintService.GetAllSprintsAsync();
+
+            // Assert
+            Assert.Empty(result);
+            await _mockRepository.Received(1).GetAllSprintsAsync();
+        }
+    }
+}

--- a/ScrumPilot.UnitTests/Backend/ServiceTests/StoryServiceTests.cs
+++ b/ScrumPilot.UnitTests/Backend/ServiceTests/StoryServiceTests.cs
@@ -624,5 +624,65 @@ namespace ScrumPilot.UnitTests.Backend.ServiceTests
             var httpClient = new HttpClient(handler);
             return new PbiService(httpClient, _mockConfiguration, _mockRepository);
         }
+
+        [Fact]
+        public async Task GetFilteredPbisAsync_ReturnsFilteredPbisFromRepository()
+        {
+            // Arrange
+            var expectedPbis = new List<ProductBacklogItem>
+            {
+                new ProductBacklogItem { PbiId = 1, Title = "Filtered PBI", SprintId = 1, EpicId = 2 }
+            };
+            _mockRepository.GetFilteredPbisAsync(1, 2).Returns(expectedPbis);
+
+            // Act
+            var result = await _pbiService.GetFilteredPbisAsync(1, 2);
+
+            // Assert
+            var actualPbis = result.ToList();
+            Assert.Single(actualPbis);
+            Assert.Equal(expectedPbis, actualPbis);
+            await _mockRepository.Received(1).GetFilteredPbisAsync(1, 2);
+        }
+
+        [Fact]
+        public async Task GetFilteredPbisAsync_WithSprintIdOnly_CallsRepositoryCorrectly()
+        {
+            // Arrange
+            _mockRepository.GetFilteredPbisAsync(1, null).Returns(new List<ProductBacklogItem>());
+
+            // Act
+            await _pbiService.GetFilteredPbisAsync(1, null);
+
+            // Assert
+            await _mockRepository.Received(1).GetFilteredPbisAsync(1, null);
+        }
+
+        [Fact]
+        public async Task GetFilteredPbisAsync_WithEpicIdOnly_CallsRepositoryCorrectly()
+        {
+            // Arrange
+            _mockRepository.GetFilteredPbisAsync(null, 2).Returns(new List<ProductBacklogItem>());
+
+            // Act
+            await _pbiService.GetFilteredPbisAsync(null, 2);
+
+            // Assert
+            await _mockRepository.Received(1).GetFilteredPbisAsync(null, 2);
+        }
+
+        [Fact]
+        public async Task GetFilteredPbisAsync_ReturnsEmptyList_WhenNoMatch()
+        {
+            // Arrange
+            _mockRepository.GetFilteredPbisAsync(99, 99).Returns(new List<ProductBacklogItem>());
+
+            // Act
+            var result = await _pbiService.GetFilteredPbisAsync(99, 99);
+
+            // Assert
+            Assert.Empty(result);
+            await _mockRepository.Received(1).GetFilteredPbisAsync(99, 99);
+        }
     }
 }

--- a/ScrumPilot.Web/Components/PbiCard.razor
+++ b/ScrumPilot.Web/Components/PbiCard.razor
@@ -193,7 +193,7 @@
 
                 <MudDivider Class="mb-4" />
 
-                <!-- EPIC AND SPRINT DROPDOWNS -->
+                <!-- EPIC AND SPRINT ASSIGNMENT -->
                 <div class="mb-4">
                     <MudText Typo="Typo.h6" Class="mb-3" Style="font-weight: 600;">
                         <MudIcon Icon="Icons.Material.Filled.AccountTree" Class="me-2" />
@@ -201,50 +201,72 @@
                     </MudText>
                     <MudGrid Spacing="3">
 
-                        <!-- EPIC DROPDOWN -->
+                        <!-- EPIC -->
                         <MudItem xs="12" sm="6">
-                            <MudSelect T="int?"
-                                       Value="PbiModel.EpicId"
-                                       ValueChanged="OnEpicChanged"
-                                       Label="Epic"
-                                       Variant="Variant.Outlined"
-                                       Disabled="@(epics == null)">
-                                <MudSelectItem T="int?" Value="@((int?)null)">
-                                    — Unassigned —
-                                </MudSelectItem>
-                                @if (epics != null)
-                                {
-                                    @foreach (var epic in epics)
+                            @if (isEditMode)
+                            {
+                                <MudSelect T="int?"
+                                           @bind-Value="editEpicId"
+                                           Label="Epic"
+                                           Variant="Variant.Outlined"
+                                           Disabled="@(epics == null)"
+                                           ToStringFunc="@(id => GetEpicDisplayName(id))">
+                                    <MudSelectItem T="int?" Value="@((int?)null)">
+                                        — Unassigned —
+                                    </MudSelectItem>
+                                    @if (epics != null)
                                     {
-                                        <MudSelectItem T="int?" Value="@((int?)epic.EpicId)">
-                                            @epic.Name
-                                        </MudSelectItem>
+                                        @foreach (var epic in epics)
+                                        {
+                                            <MudSelectItem T="int?" Value="@((int?)epic.EpicId)">
+                                                @epic.Name
+                                            </MudSelectItem>
+                                        }
                                     }
-                                }
-                            </MudSelect>
+                                </MudSelect>
+                            }
+                            else
+                            {
+                                <MudPaper Class="pa-3"
+                                          Style="background-color: var(--mud-palette-action-hover); border-radius: 8px;">
+                                    <MudText Typo="Typo.caption" Style="color: var(--mud-palette-text-secondary);">Epic</MudText>
+                                    <MudText Typo="Typo.body1" Style="font-weight: 600;">@GetEpicDisplayName(PbiModel.EpicId)</MudText>
+                                </MudPaper>
+                            }
                         </MudItem>
 
-                        <!-- SPRINT DROPDOWN -->
+                        <!-- SPRINT -->
                         <MudItem xs="12" sm="6">
-                            <MudSelect T="int?"
-                                       Value="PbiModel.SprintId"
-                                       ValueChanged="OnSprintChanged"
-                                       Label="Sprint"
-                                       Variant="Variant.Outlined"
-                                       Disabled="@(sprints == null)">
-                                <MudSelectItem T="int?" Value="@((int?)null)">
-                                    — Unassigned —
-                                </MudSelectItem>
-                                @if (sprints != null)
-                                {
-                                    @foreach (var sprint in sprints)
+                            @if (isEditMode)
+                            {
+                                <MudSelect T="int?"
+                                           @bind-Value="editSprintId"
+                                           Label="Sprint"
+                                           Variant="Variant.Outlined"
+                                           Disabled="@(sprints == null)"
+                                           ToStringFunc="@(id => GetSprintDisplayName(id))">
+                                    <MudSelectItem T="int?" Value="@((int?)null)">
+                                        — Unassigned —
+                                    </MudSelectItem>
+                                    @if (sprints != null)
                                     {
-                                        <MudSelectItem T="int?" Value="@((int?)sprint.SprintId)">
-                                            @(sprint.SprintGoal ?? $"Sprint {sprint.SprintId}")
-                                        </MudSelectItem>
+                                        @foreach (var sprint in sprints)
+                                        {
+                                            <MudSelectItem T="int?" Value="@((int?)sprint.SprintId)">
+                                                @(sprint.SprintGoal ?? $"Sprint {sprint.SprintId}")
+                                            </MudSelectItem>
+                                        }
                                     }
-                                }
-                            </MudSelect>
+                                </MudSelect>
+                            }
+                            else
+                            {
+                                <MudPaper Class="pa-3"
+                                          Style="background-color: var(--mud-palette-action-hover); border-radius: 8px;">
+                                    <MudText Typo="Typo.caption" Style="color: var(--mud-palette-text-secondary);">Sprint</MudText>
+                                    <MudText Typo="Typo.body1" Style="font-weight: 600;">@GetSprintDisplayName(PbiModel.SprintId)</MudText>
+                                </MudPaper>
+                            }
                         </MudItem>
 
                     </MudGrid>
@@ -378,6 +400,8 @@ else
     private string editDescription = "";
     private PbiPriority editPriority;
     private PbiPoints editStoryPoints;
+    private int? editEpicId;
+    private int? editSprintId;
 
     // Epic and Sprint data
     private List<Epic>? epics;
@@ -393,7 +417,7 @@ else
     {
         try
         {
-            epics = await Http.GetFromJsonAsync<List<Epic>>("api/epics");
+            epics = await Http.GetFromJsonAsync<List<Epic>>("api/Epic");
         }
         catch
         {
@@ -406,7 +430,7 @@ else
     {
         try
         {
-            sprints = await Http.GetFromJsonAsync<List<Sprint>>("api/sprints");
+            sprints = await Http.GetFromJsonAsync<List<Sprint>>("api/Sprint");
         }
         catch
         {
@@ -415,34 +439,18 @@ else
         }
     }
 
-    private async Task OnEpicChanged(int? epicId)
+    private string GetEpicDisplayName(int? epicId)
     {
-        if (PbiModel == null) return;
-        PbiModel.EpicId = epicId;
-        await SaveAssignment();
+        if (!epicId.HasValue) return "— Unassigned —";
+        var epic = epics?.FirstOrDefault(e => e.EpicId == epicId.Value);
+        return epic?.Name ?? $"Epic {epicId}";
     }
 
-    private async Task OnSprintChanged(int? sprintId)
+    private string GetSprintDisplayName(int? sprintId)
     {
-        if (PbiModel == null) return;
-        PbiModel.SprintId = sprintId;
-        await SaveAssignment();
-    }
-
-    private async Task SaveAssignment()
-    {
-        try
-        {
-            var response = await Http.PutAsJsonAsync("api/story", PbiModel);
-            if (!response.IsSuccessStatusCode)
-            {
-                errorMessage = "Failed to save assignment.";
-            }
-        }
-        catch
-        {
-            errorMessage = "Failed to connect to server.";
-        }
+        if (!sprintId.HasValue) return "— Unassigned —";
+        var sprint = sprints?.FirstOrDefault(s => s.SprintId == sprintId.Value);
+        return sprint?.SprintGoal ?? $"Sprint {sprintId}";
     }
 
     // Delete methods
@@ -463,7 +471,7 @@ else
 
         try
         {
-            var response = await Http.DeleteAsync($"api/story/{PbiModel.PbiId}");
+            var response = await Http.DeleteAsync($"api/Pbi/{PbiModel.PbiId}");
             if (response.IsSuccessStatusCode)
             {
                 showDeleteConfirm = false;
@@ -492,6 +500,8 @@ else
         editDescription = PbiModel.Description ?? "";
         editPriority = PbiModel.Priority;
         editStoryPoints = PbiModel.StoryPoints;
+        editEpicId = PbiModel.EpicId;
+        editSprintId = PbiModel.SprintId;
         titleError = false;
         errorMessage = "";
         isEditMode = true;
@@ -510,6 +520,8 @@ else
         PbiModel.Description = editDescription;
         PbiModel.Priority = editPriority;
         PbiModel.StoryPoints = editStoryPoints;
+        PbiModel.EpicId = editEpicId;
+        PbiModel.SprintId = editSprintId;
         PbiModel.LastUpdated = DateTime.Now;
 
         titleError = false;

--- a/ScrumPilot.Web/Pages/ScrumBoard.razor
+++ b/ScrumPilot.Web/Pages/ScrumBoard.razor
@@ -32,9 +32,11 @@
 
                     <MudSelectItem T="int?" Value="@((int?)null)">All</MudSelectItem>
 
-                    @foreach (var sprint in SprintOptions)
+                    @foreach (var sprint in _sprints)
                     {
-                        <MudSelectItem T="int?" Value="@sprint">Sprint @sprint</MudSelectItem>
+                        <MudSelectItem T="int?" Value="@((int?)sprint.SprintId)">
+                            @(sprint.SprintGoal ?? $"Sprint {sprint.SprintId}")
+                        </MudSelectItem>
                     }
                 </MudSelect>
 
@@ -48,21 +50,23 @@
 
                     <MudSelectItem T="int?" Value="@((int?)null)">All</MudSelectItem>
 
-                    @foreach (var epic in EpicOptions)
+                    @foreach (var epic in _epics)
                     {
-                        <MudSelectItem T="int?" Value="@epic">Epic @epic</MudSelectItem>
+                        <MudSelectItem T="int?" Value="@((int?)epic.EpicId)">
+                            @epic.Name
+                        </MudSelectItem>
                     }
                 </MudSelect>
             </MudStack>
 
-            @if (!FilteredItems.Any())
+            @if (!Items.Any())
             {
                 <MudAlert Severity="Severity.Info" Dense="true" Class="mb-4" Icon="@Icons.Material.Filled.Info">
                     No PBIs match the selected filters.
                 </MudAlert>
             }
 
-            <SwimLanes Items="@FilteredItems"
+            <SwimLanes Items="@Items"
                        OnItemDropped="OnItemDropped"
                        OnPbiSelected="OpenPbiDetails" />
         </MudContainer>
@@ -100,12 +104,10 @@
 
 @code {
 
-    
     private List<ProductBacklogItem> Items = new();
-    private List<ProductBacklogItem> FilteredItems = new();
 
-    private List<int?> SprintOptions = new();
-    private List<int?> EpicOptions = new();
+    private List<Sprint> _sprints = new();
+    private List<Epic> _epics = new();
 
     private int? SelectedSprintId = null;
     private int? SelectedEpicId = null;
@@ -116,8 +118,23 @@
 
     protected override async Task OnInitializedAsync()
     {
+        await LoadDropdownsAsync();
         await LoadPbisAsync();
-        ApplyFilters();
+    }
+
+    private async Task LoadDropdownsAsync()
+    {
+        try
+        {
+            var sprintsTask = Http.GetFromJsonAsync<List<Sprint>>("api/Sprint");
+            var epicsTask = Http.GetFromJsonAsync<List<Epic>>("api/Epic");
+            _sprints = await sprintsTask ?? new();
+            _epics = await epicsTask ?? new();
+        }
+        catch
+        {
+            // Dropdowns will be empty if API is unreachable
+        }
     }
 
     private async Task LoadPbisAsync(bool showLoading = true)
@@ -126,17 +143,15 @@
         {
             _loading = true;
             Items = new();
-            FilteredItems = new();
         }
 
         try
         {
-            var pbis = await Http.GetFromJsonAsync<List<ProductBacklogItem>>("api/Pbi/GetNonDraftPBIs");
+            var url = BuildPbiUrl();
+            var pbis = await Http.GetFromJsonAsync<List<ProductBacklogItem>>(url);
             if (pbis is not null)
             {
                 Items = pbis;
-                BuildFilterOptions();
-                ApplyFilters();
             }
         }
         catch
@@ -149,51 +164,28 @@
         }
     }
 
+    private string BuildPbiUrl()
+    {
+        var query = new List<string>();
+        if (SelectedSprintId.HasValue)
+            query.Add($"sprintId={SelectedSprintId.Value}");
+        if (SelectedEpicId.HasValue)
+            query.Add($"epicId={SelectedEpicId.Value}");
 
-    private Task OnSprintChanged(int? value)
+        var baseUrl = "api/Pbi/getNonDraftPbis";
+        return query.Count > 0 ? $"{baseUrl}?{string.Join("&", query)}" : baseUrl;
+    }
+
+    private async Task OnSprintChanged(int? value)
     {
         SelectedSprintId = value;
-        ApplyFilters();
-        return Task.CompletedTask;
+        await LoadPbisAsync(showLoading: false);
     }
 
-    private Task OnEpicChanged(int? value)
+    private async Task OnEpicChanged(int? value)
     {
         SelectedEpicId = value;
-        ApplyFilters();
-        return Task.CompletedTask;
-    }
-    private void BuildFilterOptions()
-    {
-        SprintOptions = Items
-            .Select(i => i.SprintId)
-            .Where(id => id.HasValue)
-            .Distinct()
-            .OrderBy(id => id)
-            .ToList();
-
-        EpicOptions = Items
-            .Select(i => i.EpicId)
-            .Where(id => id.HasValue)
-            .Distinct()
-            .OrderBy(id => id)
-            .ToList();
-    }
-    private void ApplyFilters()
-    {
-        IEnumerable<ProductBacklogItem> query = Items;
-
-        if (SelectedSprintId.HasValue)
-        {
-            query = query.Where(item => item.SprintId == SelectedSprintId);
-        }
-
-        if (SelectedEpicId.HasValue)
-        {
-            query = query.Where(item => item.EpicId == SelectedEpicId);
-        }
-
-        FilteredItems = query.ToList();
+        await LoadPbisAsync(showLoading: false);
     }
 
    
@@ -237,7 +229,6 @@
                 if (index >= 0)
                 {
                     Items[index] = updatedPbi;
-                    ApplyFilters();
                 }
             }
         }


### PR DESCRIPTION
# Pull Request

## Description
This adds all backend controllers and services for the Epic and Sprint filtering. Implemented the function calls on PBI card and Scrum board to pull from the endpoints. Added unit testing for all new controllers and services.

Cleaned up PBI card and changed Epic and Sprint Call functions so it doesn't return the raw int in the table. Changed the drop-down box to a static feature unless editing. Implemented the edit function to hit the controllers 

Scrum board now pulls correct database tables for Sprint and Epic and has filtering functions implemented
## Related Issues
Closes #124 

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Passes build tests
- [ ] Linting passes
- [ ] PBI Card and Scrum Board pull correct data
- [ ] Edits persist to the Data base 