### PR TITLE
Scrumlord audio fixes: filename structure, silence detection, error handling

### DIFF
--- a/discord-bot/recorder.js
+++ b/discord-bot/recorder.js
@@ -47,7 +47,7 @@ function getDisplayName(guild, userId) {
 
 function subscribeUser(receiver, userId, session) {
   if (session.userRecordings.has(userId)) return;
-  const userOutputPath = path.join(__dirname, `recording-${session.recordingTimestamp}-${userId}.ogg`);
+  const userOutputPath = path.join(__dirname, `recording-${session.recordingTimestamp}-${session.channelName}-${session.categoryName}-${userId}.ogg`);
 
   const userFfmpeg = spawn(ffmpegStatic, [
     '-f', 's16le',
@@ -102,6 +102,10 @@ async function startRecording(guild, voiceChannel) {
     selfMute: true,
   });
 
+  connection.on('error', (err) => {
+    console.warn('[Recorder] Voice connection error:', err.message);
+  });
+
   connection.once(VoiceConnectionStatus.Ready, async () => {
     console.log('[Recorder] Connected to voice channel.');
 
@@ -109,6 +113,8 @@ async function startRecording(guild, voiceChannel) {
       recordingTimestamp: Date.now(),
       userRecordings: new Map(),
       connection,
+      channelName: voiceChannel.name.replace(/\s+/g, '-'),
+      categoryName: (voiceChannel.parent?.name || 'uncategorized').replace(/\s+/g, '-'),
     };
     activeSessions.set(voiceChannel.id, session);
     const receiver = connection.receiver;
@@ -255,6 +261,27 @@ async function transcribeMultiTrack(guild, userRecordings, timestamp, recapChann
       continue;
     }
 
+    // Check if track is entirely silent before processing
+    const isSilent = await new Promise((resolve) => {
+      const probe = spawn(ffmpegStatic, [
+        '-i', outputPath,
+        '-af', 'silencedetect=noise=-40dB:duration=0.5',
+        '-f', 'null', '-'
+      ]);
+      let stderr = '';
+      probe.stderr.on('data', d => { stderr += d.toString(); });
+      probe.on('close', () => {
+        // If silence_end never appears, the whole file is silence
+        resolve(!stderr.includes('silence_end'));
+      });
+    });
+
+    if (isSilent) {
+      console.log(`[Recorder] ${displayName}'s track is silent, skipping.`);
+      fs.unlinkSync(outputPath);
+      continue;
+    }
+
     let compressedPath;
     try {
       compressedPath = await compressAudio(outputPath, controlChannel);
@@ -283,6 +310,10 @@ async function transcribeMultiTrack(guild, userRecordings, timestamp, recapChann
           ? `⚠️ ${displayName}'s audio track appears corrupted and could not be processed.`
           : `⚠️ Something went wrong processing ${displayName}'s audio track.`
       );
+      if (fs.existsSync(outputPath)) {
+        fs.renameSync(outputPath, outputPath + '.corrupted');
+        console.log(`[Recorder] Renamed to ${outputPath}.corrupted`);
+      }
     }
   }
 

--- a/discord-bot/reprocess.js
+++ b/discord-bot/reprocess.js
@@ -71,11 +71,21 @@
           ? `⚠️ Recording from ${dateString} appears to be corrupted and could not be processed.`
           : `⚠️ Something went wrong processing the recording from ${dateString}.`
       );
+      if (fs.existsSync(filePath)) {
+        fs.renameSync(filePath, filePath + '.corrupted');
+        console.log(`[Reprocess] Renamed to ${filePath}.corrupted`);
+      }
     }
   }
 
   // Multi-track handler for new per-user recordings
   async function reprocessMultiTrack(guild, timestamp, userFiles, recapChannel, controlChannel) {
+    // get channel and category from the first file's name
+    const firstFilename = path.basename(userFiles[0].filePath);
+    const nameMatch = firstFilename.match(/^recording-\d+-(.+?)-(.+?)-\d+\.ogg$/);
+    const mockVoiceChannel = nameMatch
+      ? { name: nameMatch[1].replace(/-/g, ' '), parent: { name: nameMatch[2].replace(/-/g, ' ') } }
+      : { name: 'unknown-channel', parent: { name: 'uncategorized' } };
     const dateString = formatDate(timestamp);
     console.log(`[Reprocess] Processing multi-track session from ${dateString} (${userFiles.length} tracks)`);
     await controlChannel.send(`🔄 Reprocessing ${userFiles.length}-track recording from ${dateString}...`);
@@ -90,7 +100,7 @@
       });
     });
 
-    await transcribeMultiTrack(guild, userRecordings, timestamp, recapChannel, controlChannel);
+    await transcribeMultiTrack(guild, userRecordings, timestamp, recapChannel, controlChannel, mockVoiceChannel);
   }
 
   client.once('clientReady', async () => {
@@ -126,11 +136,13 @@
 
     for (const filePath of allOggs) {
       const filename = path.basename(filePath);
-      const multiMatch = filename.match(/^recording-(\d+)-(\d+)\.ogg$/);
+      const multiMatch = filename.match(/^recording-(\d+)-(.+?)-(.+?)-(\d+)\.ogg$/) || filename.match(/^recording-(\d+)-(\d+)\.ogg$/);
       const singleMatch = filename.match(/^recording-(\d+)\.ogg$/);
 
       if (multiMatch) {
-        const [, timestamp, userId] = multiMatch;
+        const isNewFormat = multiMatch[0].split('-').length > 3;
+        const timestamp = multiMatch[1];
+        const userId = isNewFormat ? multiMatch[4] : multiMatch[2];
         if (!multiTrackGroups.has(timestamp)) multiTrackGroups.set(timestamp, []);
         multiTrackGroups.get(timestamp).push({ userId, filePath });
       } else if (singleMatch) {


### PR DESCRIPTION
## Description
A collection of reliability and correctness improvements to the voice recording and reprocessing pipeline.

## Changes

### `recorder.js`
- Added `connection.on('error', ...)` handler to prevent unhandled voice connection errors from crashing the bot
- Added `channelName` and `categoryName` to the session object, sourced from the voice channel and its Discord category
- Updated `subscribeUser` to embed `channelName` and `categoryName` in the recording filename: `recording-<timestamp>-<channelName>-<categoryName>-<userId>.ogg`
- Added silence detection via ffmpeg `silencedetect` filter before attempting transcription — silent tracks are deleted and skipped cleanly rather than failing
- Added `.corrupted` rename on failed tracks so failed files are identifiable and not picked up on subsequent reprocess runs

### `reprocess.js`
- Updated `multiMatch` regex to handle both old filename format (`recording-<timestamp>-<userId>.ogg`) and new format (`recording-<timestamp>-<channelName>-<categoryName>-<userId>.ogg`)
- Updated `reprocessMultiTrack` to parse `channelName` and `categoryName` from the filename and construct a `mockVoiceChannel` object, so recaps are correctly tagged with `[CategoryName]` for sprint summarizer filtering
- Added `.corrupted` rename in `reprocessSingleFile` catch block so failed single-track files are identifiable

## Testing
- Run `node reprocess.js` with a mix of old and new format `.ogg` files and verify both are grouped and processed correctly
- Verify silent tracks are skipped without error
- Verify failed tracks are renamed to `.corrupted`
- Join a voice channel and verify new recordings use the new filename format
- Verify recap posts include the correct `[CategoryName]` tag

## Related Issues
Closes #XX

## Checklist
- [ ] Tests added/updated
- [ ] Documentation updated
- [ ] Linting passes